### PR TITLE
Add recommended extensions per LWC Trailhead

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "salesforce.salesforcedx-vscode",
+    "salesforce.salesforcedx-vscode-lwc",
+    "EditorConfig.editorconfig",
+  ]
+}


### PR DESCRIPTION
VS Code projects support [extension recommendations](https://code.visualstudio.com/docs/editor/extension-gallery#_workspace-recommended-extensions).  This PR uses this to recommend:
1. The extensions listed in the [Lightning Web Components Trailhead](https://trailhead.salesforce.com/content/learn/projects/quick-start-lightning-web-components/set-up-visual-studio-code)
2. editorconfig, for which we include [editorconfig](https://github.com/trailheadapps/lwc-recipes/blob/master/.editorconfig)


When the user opens the project they see a popup like this:

![screen shot 2018-12-26 at 4 42 46 pm](https://user-images.githubusercontent.com/1381403/50458057-4f97ba00-092e-11e9-817c-dd4d1854637d.png)

Clicking _Show Recommendations_ opens the extensions panel to the recommended filter like this:

![screen shot 2018-12-26 at 4 55 19 pm](https://user-images.githubusercontent.com/1381403/50458166-16137e80-092f-11e9-9bee-d1e0a9aa25d6.png)
