### PR TITLE
Fix Apex return statement

### DIFF
--- a/force-app/main/default/classes/ContactController.cls
+++ b/force-app/main/default/classes/ContactController.cls
@@ -7,6 +7,9 @@ public with sharing class ContactController {
 
     @AuraEnabled(cacheable=true)
     public static List<Contact> findContacts(String searchKey) {
+        if (searchKey.equals('')) {
+            return new List<Contact>();
+        }
         String key = '%' + searchKey + '%';
         return [SELECT Id, Name, Title, Phone, Email, Picture__c FROM Contact WHERE Name LIKE :key AND Picture__c != null LIMIT 10];
     }


### PR DESCRIPTION
If an empty string is passed down as a parameter this Apex call returns the full list of all Contact records. For example is when the user enters data in `contactCompositionSearch`, and then clears the data.

This fix checks the searchKey parameter and returns an empty list in case an empty string is the parameter.