### PR TITLE
Add method header to `samePageRef`

### DIFF
--- a/force-app/main/default/lwc/pubsub/pubsub.js
+++ b/force-app/main/default/lwc/pubsub/pubsub.js
@@ -6,6 +6,11 @@
 
 const events = {};
 
+/**
+ * Confirm that two page references have the same attributes
+ * @param {object} pageRef1 - The first page reference
+ * @param {object} pageRef2 - The second page reference
+ */
 const samePageRef = (pageRef1, pageRef2) => {
     const obj1 = pageRef1.attributes;
     const obj2 = pageRef2.attributes;


### PR DESCRIPTION
An internal code review of code that used this raised the issue that this method had no header comment. Added here to help others in similar boats.