### PR TITLE
Fix missing key for 'fields' in wireGetRecordStaticContact.js

### DIFF
--- a/force-app/main/default/lwc/wireGetRecordStaticContact/wireGetRecordStaticContact.js
+++ b/force-app/main/default/lwc/wireGetRecordStaticContact/wireGetRecordStaticContact.js
@@ -11,7 +11,7 @@ const fields = [NAME_FIELD, TITLE_FIELD, PHONE_FIELD, EMAIL_FIELD];
 export default class WireGetRecordStaticContact extends LightningElement {
     @api recordId;
 
-    @wire(getRecord, { recordId: '$recordId', fields })
+    @wire(getRecord, { recordId: '$recordId', fields: fields })
     contact;
 
     get name() {


### PR DESCRIPTION
the declaration for the @wire(getRecord, { recordId: '$recordId', fields: fields }) is missing the name of the fields property