### PR TITLE
add collectCoverageFrom for Windows

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
             '<rootDir>/force-app/test/jest-mocks/lightning/uiRecordApi'
     },
     collectCoverageFrom: [
-        "force-app/main/default/lwc/**/*.js",
-        "!**/node_modules/**"
+        'force-app/main/default/lwc/**/*.js',
+        '!**/node_modules/**'
     ]
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,5 +9,9 @@ module.exports = {
             '<rootDir>/force-app/test/jest-mocks/lightning/platformShowToastEvent',
         '^lightning/uiRecordApi$':
             '<rootDir>/force-app/test/jest-mocks/lightning/uiRecordApi'
-    }
+    },
+    collectCoverageFrom: [
+        "force-app/main/default/lwc/**/*.js",
+        "!**/node_modules/**"
+    ]
 };


### PR DESCRIPTION
As reported in https://github.com/salesforce/sfdx-lwc-jest/issues/71, code coverage numbers are reported as 0% on Windows machines without the `collectCoverageFrom` Jest config option.