### PR TITLE
Update lwc-jest to sfdx-lwc-jest

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,6 @@ To set up the formatting and linting pre-commit hook:
 1. Install [Node.js](https://nodejs.org) if you haven't already done so
 2. Run `npm install` in your project's root folder to install the ESLint and Prettier modules (Note: Mac users should verify that Xcode command line tools are installed before running this command.)
 
-> Note: This projects also contains [Jest](https://jestjs.io) tests for unit testing Lightning Web Components. If you experience errors regarding `deasync` when running `npm install` please check out the troubleshooting information in the [lwc-jest repository](https://github.com/salesforce/lwc-jest#troubleshooting-deasync-installation-errors).
-
 Prettier and ESLint will now run automatically every time you commit changes. The commit will fail if linting errors are detected. You can also run the formatting and linting from the command line using the following commands (check out [package.json](./package.json) for the full list):
 
 ```

--- a/force-app/main/default/lwc/apexStaticSchema/__tests__/apexStaticSchema.test.js
+++ b/force-app/main/default/lwc/apexStaticSchema/__tests__/apexStaticSchema.test.js
@@ -1,6 +1,6 @@
 import { createElement } from 'lwc';
 import ApexStaticSchema from 'c/apexStaticSchema';
-import { registerApexTestWireAdapter } from '@salesforce/lwc-jest';
+import { registerApexTestWireAdapter } from '@salesforce/sfdx-lwc-jest';
 import getSingleContact from '@salesforce/apex/ContactController.getSingleContact';
 
 // Realistic data with a single record

--- a/force-app/main/default/lwc/apexWireMethodToFunction/__tests__/apexWireMethodToFunction.test.js
+++ b/force-app/main/default/lwc/apexWireMethodToFunction/__tests__/apexWireMethodToFunction.test.js
@@ -1,6 +1,6 @@
 import { createElement } from 'lwc';
 import ApexWireMethodToFunction from 'c/apexWireMethodToFunction';
-import { registerApexTestWireAdapter } from '@salesforce/lwc-jest';
+import { registerApexTestWireAdapter } from '@salesforce/sfdx-lwc-jest';
 import getContactList from '@salesforce/apex/ContactController.getContactList';
 
 // Realistic data with a list of contacts

--- a/force-app/main/default/lwc/apexWireMethodToProperty/__tests__/apexWireMethodToProperty.test.js
+++ b/force-app/main/default/lwc/apexWireMethodToProperty/__tests__/apexWireMethodToProperty.test.js
@@ -1,6 +1,6 @@
 import { createElement } from 'lwc';
 import ApexWireMethodToProperty from 'c/apexWireMethodToProperty';
-import { registerApexTestWireAdapter } from '@salesforce/lwc-jest';
+import { registerApexTestWireAdapter } from '@salesforce/sfdx-lwc-jest';
 import getContactList from '@salesforce/apex/ContactController.getContactList';
 
 // Realistic data with a list of contacts

--- a/force-app/main/default/lwc/apexWireMethodWithComplexParams/__tests__/apexWireMethodWithComplexParams.test.js
+++ b/force-app/main/default/lwc/apexWireMethodWithComplexParams/__tests__/apexWireMethodWithComplexParams.test.js
@@ -1,6 +1,6 @@
 import { createElement } from 'lwc';
 import ApexWireMethodWithComplexParams from 'c/apexWireMethodWithComplexParams';
-import { registerApexTestWireAdapter } from '@salesforce/lwc-jest';
+import { registerApexTestWireAdapter } from '@salesforce/sfdx-lwc-jest';
 import checkApexTypes from '@salesforce/apex/ApexTypesController.checkApexTypes';
 
 // Sample default values for wired Apex call

--- a/force-app/main/default/lwc/apexWireMethodWithParams/__tests__/apexWireMethodWithParams.test.js
+++ b/force-app/main/default/lwc/apexWireMethodWithParams/__tests__/apexWireMethodWithParams.test.js
@@ -1,6 +1,6 @@
 import { createElement } from 'lwc';
 import ApexWireMethodWithParams from 'c/apexWireMethodWithParams';
-import { registerApexTestWireAdapter } from '@salesforce/lwc-jest';
+import { registerApexTestWireAdapter } from '@salesforce/sfdx-lwc-jest';
 import findContacts from '@salesforce/apex/ContactController.findContacts';
 
 // Realistic data with a list of contacts

--- a/force-app/main/default/lwc/contactList/__tests__/contactList.test.js
+++ b/force-app/main/default/lwc/contactList/__tests__/contactList.test.js
@@ -1,6 +1,6 @@
 import { createElement } from 'lwc';
 import ContactList from 'c/contactList';
-import { registerApexTestWireAdapter } from '@salesforce/lwc-jest';
+import { registerApexTestWireAdapter } from '@salesforce/sfdx-lwc-jest';
 import getContactList from '@salesforce/apex/ContactController.getContactList';
 
 // Realistic data with a list of contacts

--- a/force-app/main/default/lwc/eventBubbling/__tests__/eventBubbling.test.js
+++ b/force-app/main/default/lwc/eventBubbling/__tests__/eventBubbling.test.js
@@ -1,6 +1,6 @@
 import { createElement } from 'lwc';
 import EventBubbling from 'c/eventBubbling';
-import { registerApexTestWireAdapter } from '@salesforce/lwc-jest';
+import { registerApexTestWireAdapter } from '@salesforce/sfdx-lwc-jest';
 import getContactList from '@salesforce/apex/ContactController.getContactList';
 
 // Realistic data with a list of records

--- a/force-app/main/default/lwc/eventWithData/__tests__/eventWithData.test.js
+++ b/force-app/main/default/lwc/eventWithData/__tests__/eventWithData.test.js
@@ -1,6 +1,6 @@
 import { createElement } from 'lwc';
 import EventWithData from 'c/eventWithData';
-import { registerApexTestWireAdapter } from '@salesforce/lwc-jest';
+import { registerApexTestWireAdapter } from '@salesforce/sfdx-lwc-jest';
 import getContactList from '@salesforce/apex/ContactController.getContactList';
 
 // Realistic data with a list of records

--- a/force-app/main/default/lwc/lds/__tests__/lds.test.js
+++ b/force-app/main/default/lwc/lds/__tests__/lds.test.js
@@ -1,6 +1,6 @@
 import { createElement } from 'lwc';
 import Lds from 'c/lds';
-import { registerApexTestWireAdapter } from '@salesforce/lwc-jest';
+import { registerApexTestWireAdapter } from '@salesforce/sfdx-lwc-jest';
 import { getNavigateCalledWith } from 'lightning/navigation';
 import getSingleContact from '@salesforce/apex/ContactController.getSingleContact';
 

--- a/force-app/main/default/lwc/ldsDeleteRecord/__tests__/ldsDeleteRecord.test.js
+++ b/force-app/main/default/lwc/ldsDeleteRecord/__tests__/ldsDeleteRecord.test.js
@@ -1,7 +1,7 @@
 import { createElement } from 'lwc';
 import LdsDeleteRecord from 'c/ldsDeleteRecord';
 import { deleteRecord } from 'lightning/uiRecordApi';
-import { registerApexTestWireAdapter } from '@salesforce/lwc-jest';
+import { registerApexTestWireAdapter } from '@salesforce/sfdx-lwc-jest';
 import getAccountList from '@salesforce/apex/AccountController.getAccountList';
 
 // Realistic data with a list of contacts

--- a/force-app/main/default/lwc/miscContentAsset/__tests__/miscContentAsset.test.js
+++ b/force-app/main/default/lwc/miscContentAsset/__tests__/miscContentAsset.test.js
@@ -14,7 +14,7 @@ describe('c-misc-content-asset', () => {
             'img[alt="Recipes logo"]'
         );
         expect(imgRecipesEl).not.toBeNull();
-        // lwc-jest automocks @salesforce/contentAsset, and returns localhost/name_of_content_asset.
+        // sfdx-lwc-jest automocks @salesforce/contentAsset, and returns localhost/name_of_content_asset.
         expect(imgRecipesEl.src).toBe('http://localhost/recipes_sq_logo');
     });
 });

--- a/force-app/main/default/lwc/miscGetUserId/__tests__/miscGetUserId.test.js
+++ b/force-app/main/default/lwc/miscGetUserId/__tests__/miscGetUserId.test.js
@@ -1,7 +1,7 @@
 import { createElement } from 'lwc';
 import MiscGetUserId from 'c/miscGetUserId';
 
-// lwc-jest automocks @salesforce/user/Id to this const value.
+// sfdx-lwc-jest automocks @salesforce/user/Id to this const value.
 const USER_ID = '005000000000000000';
 
 describe('c-misc-get-user-id', () => {

--- a/force-app/main/default/lwc/miscStaticResource/__tests__/miscStaticResource.test.js
+++ b/force-app/main/default/lwc/miscStaticResource/__tests__/miscStaticResource.test.js
@@ -14,7 +14,7 @@ describe('c-misc-static-resource', () => {
             'img[alt="Trailhead logo"]'
         );
         expect(imgTrailheadEl).not.toBeNull();
-        // lwc-jest automocks @salesforce/resourceUsl, and returns localhost/name_of_resource.
+        // sfdx-lwc-jest automocks @salesforce/resourceUsl, and returns localhost/name_of_resource.
         expect(imgTrailheadEl.src).toBe('http://localhost/trailhead_logo');
 
         // Query for img element that uses a static image resource within a zip file
@@ -22,7 +22,7 @@ describe('c-misc-static-resource', () => {
             'img[alt="Einstein logo"]'
         );
         expect(imgEinsteinEl).not.toBeNull();
-        // lwc-jest automocks @salesforce/resourceUsl, and returns localhost/name_of_resource.
+        // sfdx-lwc-jest automocks @salesforce/resourceUsl, and returns localhost/name_of_resource.
         expect(imgEinsteinEl.src).toBe(
             'http://localhost/trailhead_characters/images/einstein.png'
         );

--- a/force-app/main/default/lwc/modal/__tests__/modal.test.js
+++ b/force-app/main/default/lwc/modal/__tests__/modal.test.js
@@ -36,7 +36,7 @@ describe('c-modal', () => {
         expect(headerSlotEl).toBeNull();
     });
 
-    // lwc-jest cannot validate slotchange events. We're only checking
+    // sfdx-lwc-jest cannot validate slotchange events. We're only checking
     // here if the empty h2 div is rendered.
     it('renders the header slot when no public header property is set', () => {
         // Create initial element

--- a/force-app/main/default/lwc/pubsubContactDetails/__tests__/pubsubContactDetails.test.js
+++ b/force-app/main/default/lwc/pubsubContactDetails/__tests__/pubsubContactDetails.test.js
@@ -6,7 +6,7 @@ import { getRecord } from 'lightning/uiRecordApi';
 import {
     registerLdsTestWireAdapter,
     registerTestWireAdapter
-} from '@salesforce/lwc-jest';
+} from '@salesforce/sfdx-lwc-jest';
 import { CurrentPageReference } from 'lightning/navigation';
 
 const mockGetRecord = require('./data/getRecord.json');

--- a/force-app/main/default/lwc/pubsubContactList/__tests__/pubsubContactList.test.js
+++ b/force-app/main/default/lwc/pubsubContactList/__tests__/pubsubContactList.test.js
@@ -4,7 +4,7 @@ import { fireEvent, registerListener, unregisterAllListeners } from 'c/pubsub';
 import {
     registerTestWireAdapter,
     registerApexTestWireAdapter
-} from '@salesforce/lwc-jest';
+} from '@salesforce/sfdx-lwc-jest';
 import findContacts from '@salesforce/apex/ContactController.findContacts';
 import { CurrentPageReference } from 'lightning/navigation';
 

--- a/force-app/main/default/lwc/pubsubSearchBar/__tests__/pubsubSearchBar.test.js
+++ b/force-app/main/default/lwc/pubsubSearchBar/__tests__/pubsubSearchBar.test.js
@@ -1,7 +1,7 @@
 import { createElement } from 'lwc';
 import PubsubSearchBar from 'c/pubsubSearchBar';
 import { fireEvent } from 'c/pubsub';
-import { registerTestWireAdapter } from '@salesforce/lwc-jest';
+import { registerTestWireAdapter } from '@salesforce/sfdx-lwc-jest';
 import { CurrentPageReference } from 'lightning/navigation';
 
 // Mock out the event firing function to verify it was called with expected parameters.

--- a/force-app/main/default/lwc/wireCurrentPageReference/__tests__/wireCurrentPageReference.test.js
+++ b/force-app/main/default/lwc/wireCurrentPageReference/__tests__/wireCurrentPageReference.test.js
@@ -1,7 +1,7 @@
 import { createElement } from 'lwc';
 import WireCurrentPageReference from 'c/wireCurrentPageReference';
 import { CurrentPageReference } from 'lightning/navigation';
-import { registerTestWireAdapter } from '@salesforce/lwc-jest';
+import { registerTestWireAdapter } from '@salesforce/sfdx-lwc-jest';
 
 // Mock realistic data
 const mockCurrentPageReference = require('./data/CurrentPageReference.json');

--- a/force-app/main/default/lwc/wireGetObjectInfo/__tests__/wireGetObjectInfo.test.js
+++ b/force-app/main/default/lwc/wireGetObjectInfo/__tests__/wireGetObjectInfo.test.js
@@ -1,6 +1,6 @@
 import { createElement } from 'lwc';
 import WireGetObjectInfo from 'c/wireGetObjectInfo';
-import { registerLdsTestWireAdapter } from '@salesforce/lwc-jest';
+import { registerLdsTestWireAdapter } from '@salesforce/sfdx-lwc-jest';
 import { getObjectInfo } from 'lightning/uiObjectInfoApi';
 
 // Mock realistic data

--- a/force-app/main/default/lwc/wireGetPicklistValues/__tests__/wireGetPicklistValues.test.js
+++ b/force-app/main/default/lwc/wireGetPicklistValues/__tests__/wireGetPicklistValues.test.js
@@ -1,6 +1,6 @@
 import { createElement } from 'lwc';
 import WireGetPicklistValues from 'c/wireGetPicklistValues';
-import { registerLdsTestWireAdapter } from '@salesforce/lwc-jest';
+import { registerLdsTestWireAdapter } from '@salesforce/sfdx-lwc-jest';
 import { getPicklistValues } from 'lightning/uiObjectInfoApi';
 
 // Mock realistic data

--- a/force-app/main/default/lwc/wireGetPicklistValuesByRecordType/__tests__/wireGetPicklistValuesByRecordType.test.js
+++ b/force-app/main/default/lwc/wireGetPicklistValuesByRecordType/__tests__/wireGetPicklistValuesByRecordType.test.js
@@ -1,6 +1,6 @@
 import { createElement } from 'lwc';
 import WireGetPicklistValuesByRecordType from 'c/wireGetPicklistValuesByRecordType';
-import { registerLdsTestWireAdapter } from '@salesforce/lwc-jest';
+import { registerLdsTestWireAdapter } from '@salesforce/sfdx-lwc-jest';
 import { getPicklistValuesByRecordType } from 'lightning/uiObjectInfoApi';
 
 // Mock realistic data

--- a/force-app/main/default/lwc/wireGetRecordDynamicContact/__tests__/wireGetRecordDynamicContact.test.js
+++ b/force-app/main/default/lwc/wireGetRecordDynamicContact/__tests__/wireGetRecordDynamicContact.test.js
@@ -1,7 +1,7 @@
 import { createElement } from 'lwc';
 import WireGetRecordDynamicContact from 'c/wireGetRecordDynamicContact';
 import { getRecord } from 'lightning/uiRecordApi';
-import { registerLdsTestWireAdapter } from '@salesforce/lwc-jest';
+import { registerLdsTestWireAdapter } from '@salesforce/sfdx-lwc-jest';
 
 // Mock realistic data
 const mockGetRecord = require('./data/getRecord.json');

--- a/force-app/main/default/lwc/wireGetRecordStaticContact/__tests__/wireGetRecordStaticContact.test.js
+++ b/force-app/main/default/lwc/wireGetRecordStaticContact/__tests__/wireGetRecordStaticContact.test.js
@@ -1,7 +1,7 @@
 import { createElement } from 'lwc';
 import WireGetRecordStaticContact from 'c/wireGetRecordStaticContact';
 import { getRecord } from 'lightning/uiRecordApi';
-import { registerLdsTestWireAdapter } from '@salesforce/lwc-jest';
+import { registerLdsTestWireAdapter } from '@salesforce/sfdx-lwc-jest';
 
 // Mock realistic data
 const mockGetRecord = require('./data/getRecord.json');

--- a/force-app/main/default/lwc/wireGetRecordUser/__tests__/wireGetRecordUser.test.js
+++ b/force-app/main/default/lwc/wireGetRecordUser/__tests__/wireGetRecordUser.test.js
@@ -1,7 +1,7 @@
 import { createElement } from 'lwc';
 import WireGetRecordUser from 'c/wireGetRecordUser';
 import { getRecord, getFieldValue } from 'lightning/uiRecordApi';
-import { registerLdsTestWireAdapter } from '@salesforce/lwc-jest';
+import { registerLdsTestWireAdapter } from '@salesforce/sfdx-lwc-jest';
 
 // Mock realistic data
 const mockGetRecord = require('./data/getRecord.json');

--- a/force-app/main/default/lwc/wireListView/__tests__/wireListView.test.js
+++ b/force-app/main/default/lwc/wireListView/__tests__/wireListView.test.js
@@ -1,7 +1,7 @@
 import { createElement } from 'lwc';
 import WireListView from 'c/wireListView';
 import { getListUi } from 'lightning/uiListApi';
-import { registerLdsTestWireAdapter } from '@salesforce/lwc-jest';
+import { registerLdsTestWireAdapter } from '@salesforce/sfdx-lwc-jest';
 
 // Mock realistic data
 const mockGetListUi = require('./data/getListUi.json');

--- a/force-app/test/jest-mocks/lightning/navigation.js
+++ b/force-app/test/jest-mocks/lightning/navigation.js
@@ -1,7 +1,7 @@
 /**
  * For the original lightning/navigation mock that comes by default with
- * @salesforce/lwc-jest, see:
- * https://github.com/salesforce/lwc-jest/blob/master/src/lightning-mocks/navigation/navigation.js
+ * @salesforce/sfdx-lwc-jest, see:
+ * https://github.com/salesforce/sfdx-lwc-jest/blob/master/src/lightning-mocks/navigation/navigation.js
  */
 export const CurrentPageReference = jest.fn();
 

--- a/force-app/test/jest-mocks/lightning/platformShowToastEvent.js
+++ b/force-app/test/jest-mocks/lightning/platformShowToastEvent.js
@@ -1,7 +1,7 @@
 /**
  * For the original lightning/platformShowToastEvent mock that comes by default with
- * @salesforce/lwc-jest, see:
- * https://github.com/salesforce/lwc-jest/blob/master/src/lightning-mocks/platformShowToastEvent/platformShowToastEvent.js
+ * @salesforce/sfdx-lwc-jest, see:
+ * https://github.com/salesforce/sfdx-lwc-jest/blob/master/src/lightning-mocks/platformShowToastEvent/platformShowToastEvent.js
  */
 
 export const ShowToastEventName = 'lightning__showtoast';

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-const { jestConfig } = require('@salesforce/lwc-jest/config');
+const { jestConfig } = require('@salesforce/sfdx-lwc-jest/config');
 module.exports = {
     ...jestConfig,
     moduleNameMapper: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,14 +96,33 @@
             }
         },
         "@babel/helper-define-map": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.4.tgz",
-            "integrity": "sha512-IX3Ln8gLhZpSuqHJSnTNBWGDE9kdkTEWl21A/K7PQ00tseBwbqCHTvNLHSBd9M0R5rER4h5Rsvj9vw0R5SieBg==",
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
+            "integrity": "sha512-fTfxx7i0B5NJqvUOBBGREnrqbTxRh7zinBANpZXAVDlsZxYdclDp467G1sQ8VZYMnAURY3RpBUAgOYT9GfzHBg==",
             "dev": true,
             "requires": {
                 "@babel/helper-function-name": "^7.1.0",
-                "@babel/types": "^7.4.4",
-                "lodash": "^4.17.11"
+                "@babel/types": "^7.5.5",
+                "lodash": "^4.17.13"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+                    "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                }
             }
         },
         "@babel/helper-explode-assignable-expression": {
@@ -146,12 +165,31 @@
             }
         },
         "@babel/helper-member-expression-to-functions": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
-            "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
+            "integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "^7.5.5"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+                    "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                }
             }
         },
         "@babel/helper-module-imports": {
@@ -164,17 +202,36 @@
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.4.tgz",
-            "integrity": "sha512-3Z1yp8TVQf+B4ynN7WoHPKS8EkdTbgAEy0nU0rs/1Kw4pDgmvYH3rz3aI11KgxKCba2cn7N+tqzV1mY2HMN96w==",
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz",
+            "integrity": "sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==",
             "dev": true,
             "requires": {
                 "@babel/helper-module-imports": "^7.0.0",
                 "@babel/helper-simple-access": "^7.1.0",
                 "@babel/helper-split-export-declaration": "^7.4.4",
                 "@babel/template": "^7.4.4",
-                "@babel/types": "^7.4.4",
-                "lodash": "^4.17.11"
+                "@babel/types": "^7.5.5",
+                "lodash": "^4.17.13"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+                    "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                }
             }
         },
         "@babel/helper-optimise-call-expression": {
@@ -193,12 +250,20 @@
             "dev": true
         },
         "@babel/helper-regex": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.4.tgz",
-            "integrity": "sha512-Y5nuB/kESmR3tKjU8Nkn1wMGEx1tjJX076HBMeL3XLQCu6vA/YRzuTW0bbb+qRnXvQGn+d6Rx953yffl8vEy7Q==",
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
+            "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
             "dev": true,
             "requires": {
-                "lodash": "^4.17.11"
+                "lodash": "^4.17.13"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                }
             }
         },
         "@babel/helper-remap-async-to-generator": {
@@ -215,15 +280,79 @@
             }
         },
         "@babel/helper-replace-supers": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.4.tgz",
-            "integrity": "sha512-04xGEnd+s01nY1l15EuMS1rfKktNF+1CkKmHoErDppjAAZL+IUBZpzT748x262HF7fibaQPhbvWUl5HeSt1EXg==",
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
+            "integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
             "dev": true,
             "requires": {
-                "@babel/helper-member-expression-to-functions": "^7.0.0",
+                "@babel/helper-member-expression-to-functions": "^7.5.5",
                 "@babel/helper-optimise-call-expression": "^7.0.0",
-                "@babel/traverse": "^7.4.4",
-                "@babel/types": "^7.4.4"
+                "@babel/traverse": "^7.5.5",
+                "@babel/types": "^7.5.5"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+                    "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.0.0"
+                    }
+                },
+                "@babel/generator": {
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
+                    "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.5.5",
+                        "jsesc": "^2.5.1",
+                        "lodash": "^4.17.13",
+                        "source-map": "^0.5.0",
+                        "trim-right": "^1.0.1"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+                    "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+                    "dev": true
+                },
+                "@babel/traverse": {
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
+                    "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.5.5",
+                        "@babel/generator": "^7.5.5",
+                        "@babel/helper-function-name": "^7.1.0",
+                        "@babel/helper-split-export-declaration": "^7.4.4",
+                        "@babel/parser": "^7.5.5",
+                        "@babel/types": "^7.5.5",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0",
+                        "lodash": "^4.17.13"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+                    "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                }
             }
         },
         "@babel/helper-simple-access": {
@@ -258,14 +387,78 @@
             }
         },
         "@babel/helpers": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz",
-            "integrity": "sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==",
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.5.tgz",
+            "integrity": "sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==",
             "dev": true,
             "requires": {
                 "@babel/template": "^7.4.4",
-                "@babel/traverse": "^7.4.4",
-                "@babel/types": "^7.4.4"
+                "@babel/traverse": "^7.5.5",
+                "@babel/types": "^7.5.5"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+                    "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.0.0"
+                    }
+                },
+                "@babel/generator": {
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
+                    "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.5.5",
+                        "jsesc": "^2.5.1",
+                        "lodash": "^4.17.13",
+                        "source-map": "^0.5.0",
+                        "trim-right": "^1.0.1"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+                    "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+                    "dev": true
+                },
+                "@babel/traverse": {
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
+                    "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.5.5",
+                        "@babel/generator": "^7.5.5",
+                        "@babel/helper-function-name": "^7.1.0",
+                        "@babel/helper-split-export-declaration": "^7.4.4",
+                        "@babel/parser": "^7.5.5",
+                        "@babel/types": "^7.5.5",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0",
+                        "lodash": "^4.17.13"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+                    "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                }
             }
         },
         "@babel/highlight": {
@@ -893,28 +1086,28 @@
             }
         },
         "@lwc/babel-plugin-component": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/@lwc/babel-plugin-component/-/babel-plugin-component-0.37.4.tgz",
-            "integrity": "sha512-MIPLKsQKaGTu19PwLexMzEQfVo9a6qvyMYc4ta3iSBaLOTA9qdL8teN5ftFEsmvWaecJt0Yc8ulQedIKnf97zg==",
+            "version": "0.37.4-220.2",
+            "resolved": "https://registry.npmjs.org/@lwc/babel-plugin-component/-/babel-plugin-component-0.37.4-220.2.tgz",
+            "integrity": "sha512-PHkQt3zyCRMMmACPdE9WAJ9nqp0mPdZ5LumW6sb7vZeE9Z6VeoEskZzkhUPywW+77u9pHIRawiYjbbV5gtwBNg==",
             "dev": true,
             "requires": {
                 "@babel/helper-module-imports": "7.0.0",
                 "@babel/plugin-proposal-class-properties": "7.1.0",
-                "@lwc/errors": "0.37.4"
+                "@lwc/errors": "0.37.4-220.2"
             }
         },
         "@lwc/compiler": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/@lwc/compiler/-/compiler-0.37.4.tgz",
-            "integrity": "sha512-dHF7hmzphxarz2O/1KGg/15hpGW/WhVSLdtWSQ58jjfRAft5ORoddTJFNWGS0pE/0o1Ux6xE7uWjHOCehHjQEg==",
+            "version": "0.37.4-220.2",
+            "resolved": "https://registry.npmjs.org/@lwc/compiler/-/compiler-0.37.4-220.2.tgz",
+            "integrity": "sha512-UQ8AX8ANOx3OYjJ5iFE87oEykqBbMrFBJgOQyheNyEn5IQITXDdy/MPSV0YKbSFr8TVncJS10Tb26JfQDIftbg==",
             "dev": true,
             "requires": {
                 "@babel/core": "7.1.0",
                 "@babel/plugin-proposal-object-rest-spread": "7.0.0",
-                "@lwc/babel-plugin-component": "0.37.4",
-                "@lwc/errors": "0.37.4",
-                "@lwc/style-compiler": "0.37.4",
-                "@lwc/template-compiler": "0.37.4",
+                "@lwc/babel-plugin-component": "0.37.4-220.2",
+                "@lwc/errors": "0.37.4-220.2",
+                "@lwc/style-compiler": "0.37.4-220.2",
+                "@lwc/template-compiler": "0.37.4-220.2",
                 "@types/chokidar": "^1.7.5",
                 "babel-preset-compat": "0.21.4",
                 "babel-preset-minify": "0.5.0-alpha.5a128fd5",
@@ -923,18 +1116,18 @@
             }
         },
         "@lwc/engine": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/@lwc/engine/-/engine-0.37.4.tgz",
-            "integrity": "sha512-2o7Fp7U3javtSHn8M+0SzqsY/Jxv0aKk49UvPCDqUOFRoT3hkIqo+k9k6PzG6rIJpPGnJGzFD+AQOHVztpqMDg==",
+            "version": "0.37.4-220.2",
+            "resolved": "https://registry.npmjs.org/@lwc/engine/-/engine-0.37.4-220.2.tgz",
+            "integrity": "sha512-K/41eTS7lrew/aoN9tNOuyCnffUfKi27pF8k+D20rbQjitOn5MzAeMHN31gelprwFxcfdnGGVCc5DkpWfRhMiA==",
             "dev": true,
             "requires": {
                 "observable-membrane": "0.26.1"
             }
         },
         "@lwc/errors": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/@lwc/errors/-/errors-0.37.4.tgz",
-            "integrity": "sha512-e3qb0oVuha/8raTowJkM2tD3oprcEmxO6rEc/eUefX49QlgjldxTcEdF7mHuS+LDoLzwhTLgx+2jVzL0CmhP/w==",
+            "version": "0.37.4-220.2",
+            "resolved": "https://registry.npmjs.org/@lwc/errors/-/errors-0.37.4-220.2.tgz",
+            "integrity": "sha512-fIetApE3x/dNo515Or1psyOta0iLQqLfq5frr9bqyorybpyqxWSPY7hyi2NX+NPXJWyjvI0g3V0vQSaKw329Kg==",
             "dev": true
         },
         "@lwc/eslint-plugin-lwc": {
@@ -944,41 +1137,40 @@
             "dev": true
         },
         "@lwc/jest-preset": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/@lwc/jest-preset/-/jest-preset-0.37.4.tgz",
-            "integrity": "sha512-a0dKXbZalEHwhShCyiP8mxn7zhxnQMzcawcVClRKy2uebFTrU9JisloiC2vDLLinsgdWgtr2+Wd3ftV802nM2Q==",
+            "version": "0.37.4-220.2",
+            "resolved": "https://registry.npmjs.org/@lwc/jest-preset/-/jest-preset-0.37.4-220.2.tgz",
+            "integrity": "sha512-rMXsa3NPFzwZl5Cbx+0jZfINo+w5ZcJOYWz/odjL2hu1Z1RF9QPAReS1Q9+JxVe2dL9kfVB0h2BHMN7UXe924Q==",
             "dev": true,
             "requires": {
-                "@lwc/jest-resolver": "0.37.4",
-                "@lwc/jest-serializer": "0.37.4",
-                "@lwc/jest-transformer": "0.37.4",
-                "@lwc/test-utils": "0.37.4"
+                "@lwc/jest-resolver": "0.37.4-220.2",
+                "@lwc/jest-serializer": "0.37.4-220.2",
+                "@lwc/jest-transformer": "0.37.4-220.2",
+                "@lwc/test-utils": "0.37.4-220.2"
             }
         },
         "@lwc/jest-resolver": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/@lwc/jest-resolver/-/jest-resolver-0.37.4.tgz",
-            "integrity": "sha512-NsNo6+d3+f+AMXDG8d46AffMD2Crt78naYJ8QkK7Dze5J4JLc7QviBHIUpj9Iq8isk0cjhVsgMEqHyjxh6Wv8A==",
+            "version": "0.37.4-220.2",
+            "resolved": "https://registry.npmjs.org/@lwc/jest-resolver/-/jest-resolver-0.37.4-220.2.tgz",
+            "integrity": "sha512-Q7Gb+2TQ4Mhl8l290SPM7+sCN7r6pb+f6zaHvYnPWcON6KXXxy3/Klj33kvvqnrjLC2QoZCRtXy6p/1zsSedng==",
             "dev": true
         },
         "@lwc/jest-serializer": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/@lwc/jest-serializer/-/jest-serializer-0.37.4.tgz",
-            "integrity": "sha512-B3DHR0KWJuji4jnDh373t2ps7FikY5AFveb62iWovhT9xgyiEWMEdAArxxEtc/z5upG6w4w6fWMnMdoinm2pog==",
+            "version": "0.37.4-220.2",
+            "resolved": "https://registry.npmjs.org/@lwc/jest-serializer/-/jest-serializer-0.37.4-220.2.tgz",
+            "integrity": "sha512-BEBWhlNSA3c2340LSXGUNHWEpRfkVDtTqZjaYrKfKfw4yZaflhfbtuBuIfynT8WERL8491W2STmLnojeqpmkew==",
             "dev": true
         },
         "@lwc/jest-transformer": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/@lwc/jest-transformer/-/jest-transformer-0.37.4.tgz",
-            "integrity": "sha512-qa0H1+E9tsmQN/vDxxC4fE9pCMxOOQC2T+1VJSquNBHzXemGFonHp3d1GvtjKF+kd7kdMHwYd/OFsNebpbO8IA==",
+            "version": "0.37.4-220.2",
+            "resolved": "https://registry.npmjs.org/@lwc/jest-transformer/-/jest-transformer-0.37.4-220.2.tgz",
+            "integrity": "sha512-v1lyri+bi1e4RmuXZXbjlPSDJLLzSRwNVYrcJLic6yY4H44ib2E8T7ofgLpHFZfXng+arfXGxIjQ8PAUcdotkw==",
             "dev": true,
             "requires": {
                 "@babel/core": "7.1.0",
                 "@babel/plugin-transform-modules-commonjs": "7.1.0",
                 "@babel/template": "~7.1.2",
-                "@lwc/errors": "0.37.4",
-                "babel-preset-jest": "^24.0.0",
-                "deasync": "0.1.14"
+                "@lwc/errors": "0.37.4-220.2",
+                "babel-preset-jest": "^24.0.0"
             },
             "dependencies": {
                 "@babel/template": {
@@ -995,18 +1187,18 @@
             }
         },
         "@lwc/module-resolver": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/@lwc/module-resolver/-/module-resolver-0.37.4.tgz",
-            "integrity": "sha512-Dz1hW9moypCU67WzQRcOEg4J6kNn1rSaota/s3ppy/pTeQFsqYJynFZTNNrhribQMx6+u/WXFKwqCkB6r8tOQw==",
+            "version": "0.37.4-220.2",
+            "resolved": "https://registry.npmjs.org/@lwc/module-resolver/-/module-resolver-0.37.4-220.2.tgz",
+            "integrity": "sha512-tycKV4OjFXYEWEiBt4De2C0Vz6cSXtdTQPAH9UyF94TNfkSZlC5Xk+pfoRNBByvvdnsF82MZFo5cYEtu+XQlQw==",
             "dev": true,
             "requires": {
                 "glob": "^7.1.2"
             }
         },
         "@lwc/style-compiler": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/@lwc/style-compiler/-/style-compiler-0.37.4.tgz",
-            "integrity": "sha512-rveeuf2tv3lL2iXqPidwz7MMuRr3TqZo0Pj8N7Ee/puG49d4JKnCTZkp+x4lYpksuYNKdLf8TCpq+15K0xOGwQ==",
+            "version": "0.37.4-220.2",
+            "resolved": "https://registry.npmjs.org/@lwc/style-compiler/-/style-compiler-0.37.4-220.2.tgz",
+            "integrity": "sha512-3hsCu1QXdEpvxjAIgpa3h2RnreIT0A+ER3ysW8RWe6N+vgeEIniJv6YXY+X8Ot/7VoVPmnHuFwFh+TatwOlqQw==",
             "dev": true,
             "requires": {
                 "cssnano": "~3.10.0",
@@ -1016,9 +1208,9 @@
             }
         },
         "@lwc/template-compiler": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/@lwc/template-compiler/-/template-compiler-0.37.4.tgz",
-            "integrity": "sha512-/JqAs6Jn5n7JwA9ZFGJBg+f3DtFj0K+3o8IOuUgrKtoTMKrCzF6k4GtuG29g3WR+4//MAWnF1vHLHjkZJTvwoQ==",
+            "version": "0.37.4-220.2",
+            "resolved": "https://registry.npmjs.org/@lwc/template-compiler/-/template-compiler-0.37.4-220.2.tgz",
+            "integrity": "sha512-MIhn3PrSgQSq0tCT06ukIIMS7icIhQEpj/tRFiW/VOjjUsDYUSDTxa/VF6vCMnoRIuxVvhWFzIz27B88p4zWqQ==",
             "dev": true,
             "requires": {
                 "@babel/generator": "~7.1.5",
@@ -1026,8 +1218,8 @@
                 "@babel/template": "~7.1.2",
                 "@babel/traverse": "~7.1.5",
                 "@babel/types": "~7.1.5",
-                "@lwc/errors": "0.37.4",
-                "@lwc/style-compiler": "0.37.4",
+                "@lwc/errors": "0.37.4-220.2",
+                "@lwc/style-compiler": "0.37.4-220.2",
                 "camelcase": "~5.0.0",
                 "he": "^1.1.1",
                 "parse5-with-errors": "^4.0.1"
@@ -1094,15 +1286,15 @@
             }
         },
         "@lwc/test-utils": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/@lwc/test-utils/-/test-utils-0.37.4.tgz",
-            "integrity": "sha512-5yQeW3dl+MdbCrwzmxgIRuT4xHro9FMtomCB0FZDFD0Z6Om+ekCSYiBCwvjU3qCNzmjI6Xime9rFEFIHda2zvw==",
+            "version": "0.37.4-220.2",
+            "resolved": "https://registry.npmjs.org/@lwc/test-utils/-/test-utils-0.37.4-220.2.tgz",
+            "integrity": "sha512-grrOqEwjO2mkKc5O4t3SA64lCVbKWT0G70tNfvq6BSYtakfXmES+cKFAb8x2s3U4Nc3bMcBf0HFhnXnCbIuQgg==",
             "dev": true
         },
         "@lwc/wire-service": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/@lwc/wire-service/-/wire-service-0.37.4.tgz",
-            "integrity": "sha512-GTu9G7fFzdbzBalPNnzLGMNtSv/61KkBhbRtE5ku1ByYIqucQYIpatx64aLvYl7+Fm34NjTZiVS44CkR8GcMQA==",
+            "version": "0.37.4-220.2",
+            "resolved": "https://registry.npmjs.org/@lwc/wire-service/-/wire-service-0.37.4-220.2.tgz",
+            "integrity": "sha512-WzuV2J+zvE1z480DXy+ohLrp7J6PlXXfhKeT7fqxq/RHeKHnVaoOhYm81RCPpKIV2pgzBPhdopgj8gGNjfPIIQ==",
             "dev": true
         },
         "@salesforce/eslint-config-lwc": {
@@ -1117,20 +1309,20 @@
                 "eslint-plugin-jest": "^22.0.0"
             }
         },
-        "@salesforce/lwc-jest": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/@salesforce/lwc-jest/-/lwc-jest-0.5.0.tgz",
-            "integrity": "sha512-98KQLWwJP4m+osAv7HF44Ps2bL5RWs5ANek2B4+GtbItv+iU0Q4yFJq5X9JFiaZj0W2TSHJIQYkYZaN5wjPLAg==",
+        "@salesforce/sfdx-lwc-jest": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@salesforce/sfdx-lwc-jest/-/sfdx-lwc-jest-0.5.4.tgz",
+            "integrity": "sha512-CcPrXGECEl6TR9qNu3mG8q4PxNoT0YUMvDVihwazw1/kAQhYVrYtMUB3gBuxJDoKM9azvhr2wsKxE4ZMGuQnIg==",
             "dev": true,
             "requires": {
-                "@lwc/compiler": "0.37.4",
-                "@lwc/engine": "0.37.4",
-                "@lwc/jest-preset": "0.37.4",
-                "@lwc/jest-resolver": "0.37.4",
-                "@lwc/jest-serializer": "0.37.4",
-                "@lwc/jest-transformer": "0.37.4",
-                "@lwc/module-resolver": "0.37.4",
-                "@lwc/wire-service": "0.37.4",
+                "@lwc/compiler": "0.37.4-220.2",
+                "@lwc/engine": "0.37.4-220.2",
+                "@lwc/jest-preset": "0.37.4-220.2",
+                "@lwc/jest-resolver": "0.37.4-220.2",
+                "@lwc/jest-serializer": "0.37.4-220.2",
+                "@lwc/jest-transformer": "0.37.4-220.2",
+                "@lwc/module-resolver": "0.37.4-220.2",
+                "@lwc/wire-service": "0.37.4-220.2",
                 "@salesforce/wire-service-jest-util": "^2.2.5",
                 "chalk": "^2.3.0",
                 "glob": "^7.1.2",
@@ -1242,9 +1434,9 @@
             }
         },
         "@types/node": {
-            "version": "6.14.6",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.6.tgz",
-            "integrity": "sha512-rFs9zCFtSHuseiNXxYxFlun8ibu+jtZPgRM+2ILCmeLiGeGLiIGxuOzD+cNyHegI1GD+da3R/cIbs9+xCLp13w==",
+            "version": "6.14.7",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.7.tgz",
+            "integrity": "sha512-YbPXbaynBTe0pVExPhL76TsWnxSPeFAvImIsmylpBWn/yfw+lHy+Q68aawvZHsgskT44ZAoeE67GM5f+Brekew==",
             "dev": true
         },
         "@types/normalize-package-data": {
@@ -1278,9 +1470,9 @@
             "dev": true
         },
         "acorn-globals": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.2.tgz",
-            "integrity": "sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.3.tgz",
+            "integrity": "sha512-vkR40VwS2SYO98AIeFvzWWh+xyc2qi9s7OoXSFEGIP/rOJKzjnhykaZJNnHdoq4BL2gGxI5EZOU16z896EYnOQ==",
             "dev": true,
             "requires": {
                 "acorn": "^6.0.1",
@@ -1288,9 +1480,9 @@
             },
             "dependencies": {
                 "acorn": {
-                    "version": "6.1.1",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-                    "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+                    "version": "6.2.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
+                    "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
                     "dev": true
                 }
             }
@@ -1302,9 +1494,9 @@
             "dev": true
         },
         "acorn-walk": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
-            "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+            "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
             "dev": true
         },
         "ajv": {
@@ -1460,9 +1652,9 @@
             "dev": true
         },
         "async-limiter": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-            "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+            "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
             "dev": true
         },
         "asynckit": {
@@ -1631,11 +1823,12 @@
             }
         },
         "babel-plugin-istanbul": {
-            "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.4.tgz",
-            "integrity": "sha512-dySz4VJMH+dpndj0wjJ8JPs/7i1TdSPb1nRrn56/92pKOF9VKC1FMFJmMXjzlGGusnCAqujP6PBCiKq0sVA+YQ==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
+            "integrity": "sha512-5LphC0USA8t4i1zCtjbbNb6jJj/9+X6P37Qfirc/70EQ34xKlMW+a1RHGwxGI+SwWpNwZ27HqvzAobeqaXwiZw==",
             "dev": true,
             "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
                 "find-up": "^3.0.0",
                 "istanbul-lib-instrument": "^3.3.0",
                 "test-exclude": "^5.2.3"
@@ -2050,12 +2243,6 @@
                 "tweetnacl": "^0.14.3"
             }
         },
-        "bindings": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-            "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE=",
-            "dev": true
-        },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2129,9 +2316,9 @@
             }
         },
         "bser": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
-            "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.0.tgz",
+            "integrity": "sha512-8zsjWrQkkBoLK6uxASk1nJ2SKv97ltiGDo6A3wA0/yRPz+CwmEyDo0hUrhIuukG2JHpAl3bvFIixw2/3Hi0DOg==",
             "dev": true,
             "requires": {
                 "node-int64": "^0.4.0"
@@ -2211,9 +2398,9 @@
             }
         },
         "caniuse-db": {
-            "version": "1.0.30000974",
-            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000974.tgz",
-            "integrity": "sha512-zeXkn1hbjMvXdadcyUELZnGu7OjlW3HK0956DWczM7ZJqGV4jFaPi8CidB8QiAj5xl5O9I+f7j9F0AFmXmGTpg==",
+            "version": "1.0.30000989",
+            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000989.tgz",
+            "integrity": "sha512-5pkU/t9nueoBgELZOCpK+wN4wK6MkIz1Q9lGZSgLwg4xR8EhLY9r0qj6T2bUI8Cq9pGbioEar+Zqgosk5fpbjg==",
             "dev": true
         },
         "capture-exit": {
@@ -2733,15 +2920,15 @@
             }
         },
         "cssom": {
-            "version": "0.3.6",
-            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
-            "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
+            "version": "0.3.8",
+            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+            "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
             "dev": true
         },
         "cssstyle": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.2.tgz",
-            "integrity": "sha512-43wY3kl1CVQSvL7wUY1qXkxVGkStjpkDmVjiIKX8R97uhajy8Bybay78uOtqvh7Q5GK75dNPfW0geWjE6qQQow==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
+            "integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
             "dev": true,
             "requires": {
                 "cssom": "0.3.x"
@@ -2785,16 +2972,6 @@
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
             "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
             "dev": true
-        },
-        "deasync": {
-            "version": "0.1.14",
-            "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.14.tgz",
-            "integrity": "sha512-wN8sIuEqIwyQh72AG7oY6YQODCxIp1eXzEZlZznBuwDF8Q03Tdy9QNp1BNZXeadXoklNrw+Ip1fch+KXo/+ASw==",
-            "dev": true,
-            "requires": {
-                "bindings": "~1.2.1",
-                "node-addon-api": "^1.6.0"
-            }
         },
         "debug": {
             "version": "4.1.1",
@@ -2967,9 +3144,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.155",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.155.tgz",
-            "integrity": "sha512-/ci/XgZG8jkLYOgOe3mpJY1onxPPTDY17y7scldhnSjjZqV6VvREG/LvwhRuV7BJbnENFfuDWZkSqlTh4x9ZjQ==",
+            "version": "1.3.220",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.220.tgz",
+            "integrity": "sha512-ZsaFWi+9J9Nsm4OmGM/BvZF3HEeZL4bte1+CcN9vHUcqdkOOVAXP4SeacPZ/W5uCQZEKPYBXg6yUjZx8/jpD0Q==",
             "dev": true
         },
         "elegant-spinner": {
@@ -3718,29 +3895,25 @@
             "dependencies": {
                 "abbrev": {
                     "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-                    "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-                    "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "are-we-there-yet": {
                     "version": "1.1.5",
-                    "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-                    "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3750,15 +3923,13 @@
                 },
                 "balanced-match": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
-                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-                    "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3768,43 +3939,37 @@
                 },
                 "chownr": {
                     "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-                    "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "code-point-at": {
                     "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                    "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-                    "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                    "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "debug": {
                     "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3813,29 +3978,25 @@
                 },
                 "deep-extend": {
                     "version": "0.6.0",
-                    "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-                    "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "delegates": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-                    "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "detect-libc": {
                     "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-                    "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "fs-minipass": {
                     "version": "1.2.5",
-                    "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-                    "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3844,15 +4005,13 @@
                 },
                 "fs.realpath": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                    "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "gauge": {
                     "version": "2.7.4",
-                    "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-                    "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3868,8 +4027,7 @@
                 },
                 "glob": {
                     "version": "7.1.3",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-                    "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3883,15 +4041,13 @@
                 },
                 "has-unicode": {
                     "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-                    "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "iconv-lite": {
                     "version": "0.4.24",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-                    "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3900,8 +4056,7 @@
                 },
                 "ignore-walk": {
                     "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-                    "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3910,8 +4065,7 @@
                 },
                 "inflight": {
                     "version": "1.0.6",
-                    "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                    "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3921,22 +4075,19 @@
                 },
                 "inherits": {
                     "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
-                    "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-                    "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3945,15 +4096,13 @@
                 },
                 "isarray": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "minimatch": {
                     "version": "3.0.4",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3962,15 +4111,13 @@
                 },
                 "minimist": {
                     "version": "0.0.8",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
-                    "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
-                    "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3980,8 +4127,7 @@
                 },
                 "minizlib": {
                     "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
-                    "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -3990,8 +4136,7 @@
                 },
                 "mkdirp": {
                     "version": "0.5.1",
-                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                    "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4000,15 +4145,13 @@
                 },
                 "ms": {
                     "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "needle": {
                     "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
-                    "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4019,8 +4162,7 @@
                 },
                 "node-pre-gyp": {
                     "version": "0.12.0",
-                    "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
-                    "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4038,8 +4180,7 @@
                 },
                 "nopt": {
                     "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-                    "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4049,15 +4190,13 @@
                 },
                 "npm-bundled": {
                     "version": "1.0.6",
-                    "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
-                    "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "npm-packlist": {
                     "version": "1.4.1",
-                    "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
-                    "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4067,8 +4206,7 @@
                 },
                 "npmlog": {
                     "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-                    "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4080,22 +4218,19 @@
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                    "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "once": {
                     "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                    "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4104,22 +4239,19 @@
                 },
                 "os-homedir": {
                     "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-                    "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "os-tmpdir": {
                     "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-                    "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "osenv": {
                     "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-                    "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4129,22 +4261,19 @@
                 },
                 "path-is-absolute": {
                     "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                    "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "process-nextick-args": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "rc": {
                     "version": "1.2.8",
-                    "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-                    "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4156,8 +4285,7 @@
                     "dependencies": {
                         "minimist": {
                             "version": "1.2.0",
-                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         }
@@ -4165,8 +4293,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4181,8 +4308,7 @@
                 },
                 "rimraf": {
                     "version": "2.6.3",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-                    "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4191,50 +4317,43 @@
                 },
                 "safe-buffer": {
                     "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-                    "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "sax": {
                     "version": "1.2.4",
-                    "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-                    "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "semver": {
                     "version": "5.7.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-                    "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "set-blocking": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-                    "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "signal-exit": {
                     "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-                    "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "string-width": {
                     "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4245,8 +4364,7 @@
                 },
                 "string_decoder": {
                     "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4255,8 +4373,7 @@
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4265,15 +4382,13 @@
                 },
                 "strip-json-comments": {
                     "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-                    "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "tar": {
                     "version": "4.4.8",
-                    "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-                    "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4288,15 +4403,13 @@
                 },
                 "util-deprecate": {
                     "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                    "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "wide-align": {
                     "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-                    "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4305,15 +4418,13 @@
                 },
                 "wrappy": {
                     "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-                    "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 }
@@ -5183,14 +5294,6 @@
                 "@babel/types": "^7.4.0",
                 "istanbul-lib-coverage": "^2.0.5",
                 "semver": "^6.0.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "6.1.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
-                    "integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
-                    "dev": true
-                }
             }
         },
         "istanbul-lib-report": {
@@ -5451,9 +5554,9 @@
             "dev": true
         },
         "jest-haste-map": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.0.tgz",
-            "integrity": "sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==",
+            "version": "24.8.1",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.1.tgz",
+            "integrity": "sha512-SwaxMGVdAZk3ernAx2Uv2sorA7jm3Kx+lR0grp6rMmnY06Kn/urtKx1LPN2mGTea4fCT38impYT28FfcLUhX0g==",
             "dev": true,
             "requires": {
                 "@jest/types": "^24.8.0",
@@ -6613,9 +6716,9 @@
             }
         },
         "magic-string": {
-            "version": "0.25.2",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.2.tgz",
-            "integrity": "sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.3.tgz",
+            "integrity": "sha512-6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==",
             "dev": true,
             "requires": {
                 "sourcemap-codec": "^1.4.4"
@@ -6892,12 +6995,6 @@
             "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
             "dev": true
         },
-        "node-addon-api": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.6.3.tgz",
-            "integrity": "sha512-FXWH6mqjWgU8ewuahp4spec8LkroFZK2NicOv6bNwZC3kcwZUI8LeZdG80UzTSLLhK4T7MsgNwlYDVRlDdfTDg==",
-            "dev": true
-        },
         "node-int64": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -6911,9 +7008,9 @@
             "dev": true
         },
         "node-notifier": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
-            "integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.1.tgz",
+            "integrity": "sha512-p52B+onAEHKW1OF9MGO/S7k/ahGEHfhP5/tvwYzog/5XLYOd8ZuD6vdNZdUuWMONRnKPneXV43v3s6Snx1wsCQ==",
             "dev": true,
             "requires": {
                 "growly": "^1.3.0",
@@ -9175,9 +9272,9 @@
             "dev": true
         },
         "process-nextick-args": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true
         },
         "progress": {
@@ -9187,13 +9284,13 @@
             "dev": true
         },
         "prompts": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.1.0.tgz",
-            "integrity": "sha512-+x5TozgqYdOwWsQFZizE/Tra3fKvAoy037kOyU6cgz84n8f6zxngLOV4O32kTwt9FcLCxAqw0P/c8rOr9y+Gfg==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.2.1.tgz",
+            "integrity": "sha512-VObPvJiWPhpZI6C5m60XOzTfnYg/xc/an+r9VYymj9WJW3B/DIH+REzjpAACPf8brwPeP+7vz3bIim3S+AaMjw==",
             "dev": true,
             "requires": {
-                "kleur": "^3.0.2",
-                "sisteransi": "^1.0.0"
+                "kleur": "^3.0.3",
+                "sisteransi": "^1.0.3"
             }
         },
         "property-expr": {
@@ -9209,9 +9306,9 @@
             "dev": true
         },
         "psl": {
-            "version": "1.1.32",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
-            "integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.3.0.tgz",
+            "integrity": "sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag==",
             "dev": true
         },
         "pump": {
@@ -9253,9 +9350,9 @@
             }
         },
         "react-is": {
-            "version": "16.8.6",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
-            "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+            "version": "16.9.0",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
+            "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==",
             "dev": true
         },
         "read-pkg": {
@@ -9756,9 +9853,9 @@
             }
         },
         "sisteransi": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
-            "integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.3.tgz",
+            "integrity": "sha512-SbEG75TzH8G7eVXFSN5f9EExILKfly7SUvVY5DhhYLvfhKqhDFY0OzevWa/zwak0RLRfWS5AvfMWpd9gJvr5Yg==",
             "dev": true
         },
         "slash": {
@@ -9930,9 +10027,9 @@
             }
         },
         "source-map-support": {
-            "version": "0.5.12",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
-            "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+            "version": "0.5.13",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+            "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
             "dev": true,
             "requires": {
                 "buffer-from": "^1.0.0",
@@ -9954,9 +10051,9 @@
             "dev": true
         },
         "sourcemap-codec": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz",
-            "integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg==",
+            "version": "1.4.6",
+            "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.6.tgz",
+            "integrity": "sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg==",
             "dev": true
         },
         "spdx-correct": {
@@ -10206,9 +10303,9 @@
             "dev": true
         },
         "symbol-tree": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-            "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true
         },
         "synchronous-promise": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     },
     "devDependencies": {
         "@salesforce/eslint-config-lwc": "^0.3.0",
-        "@salesforce/lwc-jest": "^0.5.0",
+        "@salesforce/sfdx-lwc-jest": "^0.5.4",
         "eslint": "^5.16.0",
         "husky": "^2.4.1",
         "lint-staged": "^8.1.5",


### PR DESCRIPTION
`@salesforce/lwc-jest` was renamed to `@salesforce/sfdx-lwc-jest`. We should update all references in the sample apps we own now since we only plan to keep the `lwc-jest` NPM package updated through Winter '20.