### PR TITLE
Gitignore for local dev and new scratch def format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ $RECYCLE.BIN/
 
 # VS Code project settings
 .vscode/
+
+# Local Development
+.localdevserver/

--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -3,10 +3,16 @@
     "edition": "Developer",
     "hasSampleData": false,
     "settings": {
-        "orgPreferenceSettings": {
-            "s1DesktopEnabled": true,
-            "selfSetPasswordInApi": true,
-            "s1EncryptedStoragePref2": false
+        "lightningExperienceSettings": {
+            "enableS1DesktopEnabled": true
+        },
+        "securitySettings": {
+            "passwordPolicies": {
+                "enableSetPasswordInApi": true
+            }
+        },
+        "mobileSettings": {
+            "enableS1EncryptedStoragePref2": false
         }
     }
 }


### PR DESCRIPTION
Ignore the created localdevserver

project scratch def is changing the format for declaring perms.
Without this you get a message in your console to do this.