### PR TITLE
Simplified the If logic

### DIFF
--- a/force-app/main/default/lwc/apexWireMethodToFunction/apexWireMethodToFunction.js
+++ b/force-app/main/default/lwc/apexWireMethodToFunction/apexWireMethodToFunction.js
@@ -7,12 +7,9 @@ export default class ApexWireMethodToFunction extends LightningElement {
 
     @wire(getContactList)
     wiredContacts({ error, data }) {
-        if (data) {
+        if (data || error) {
             this.contacts = data;
-            this.error = undefined;
-        } else if (error) {
             this.error = error;
-            this.contacts = undefined;
         }
     }
 }


### PR DESCRIPTION
Either data or error is going to be undefined. So, we don't have to explicitly pass the undefined to the reactive properties. Rendering of error and data will be based on truthy values on HTML.  To prevent the execution of logic on render inside wire we can use (data || error).

Please give me a reason, If the commit gets rejected. 

I will also contribute change every instance of IF ELSE logics with care if this way is accepted.