### PR TITLE
Adding a mock for GenerateUrl

### DIFF
--- a/force-app/test/jest-mocks/lightning/navigation.js
+++ b/force-app/test/jest-mocks/lightning/navigation.js
@@ -5,17 +5,20 @@
  */
 export const CurrentPageReference = jest.fn();
 
-let _pageReference, _replace;
+let _navigatePageReference, _generatePageReference, _replace;
 
 const Navigate = Symbol('Navigate');
 const GenerateUrl = Symbol('GenerateUrl');
 export const NavigationMixin = Base => {
     return class extends Base {
         [Navigate](pageReference, replace) {
-            _pageReference = pageReference;
+            _navigatePageReference = pageReference;
             _replace = replace;
         }
-        [GenerateUrl](pageReference) {}
+        [GenerateUrl](pageReference) {
+            _generatePageReference = pageReference;
+            return new Promise(resolve => resolve('https://www.example.com'));
+        }
     };
 };
 NavigationMixin.Navigate = Navigate;
@@ -32,3 +35,5 @@ export const getNavigateCalledWith = () => {
         replace: _replace
     };
 };
+
+export const getGenerateUrlCalledWith = () => ({ pageReference: _generatePageReference });


### PR DESCRIPTION
Our team had a dev implement the `NavigationMixin.GenerateUrl` method in a `connectedCallback` similar to [what's detailed in the documentation](https://developer.salesforce.com/docs/component-library/bundle/lightning-navigation/documentation). Unfortunately, when running the test, as soon as the component was appended, an error was received of `cannot read property then of undefined` because [the default implementation is just a stub](https://github.com/salesforce/sfdx-lwc-jest/blob/4f5c03efa9cfb9d4e85ed764fa6ef6af18ff3ef2/src/lightning-stubs/navigation/navigation.js#L14).

Since `NavigationMixin.Navigate` has some extra logic built into the mock to be used in tests, we added something very similar for `GenerateUrl` and thought other developers would also find it useful.

We use `https://www.example.com` as the generated URL since it is a reserved domain that's safe to reference in tests, but provides the structure of a "real" URL. We could just as easily have it be an empty String or some dummy value like "Some URL", though, if that would be preferred. We considered adding in some logic to make the URL configurable in case the implementation cares about what's returned, but ultimately decided that would be enough of an edge case that a developer could add that kind of functionality themselves as needed and what we had was generic enough for most purposes.