### PR TITLE
Input validation for samePageRef

### DIFF
--- a/force-app/main/default/lwc/pubsub/pubsub.js
+++ b/force-app/main/default/lwc/pubsub/pubsub.js
@@ -12,13 +12,18 @@ const events = {};
  * @param {object} pageRef2 - The second page reference
  */
 const samePageRef = (pageRef1, pageRef2) => {
-    const obj1 = pageRef1.attributes;
-    const obj2 = pageRef2.attributes;
-    return Object.keys(obj1)
-        .concat(Object.keys(obj2))
-        .every((key) => {
-            return obj1[key] === obj2[key];
-        });
+    if (pageRef1 && pageRef2) {
+        const obj1 = pageRef1.attributes;
+        const obj2 = pageRef2.attributes;
+        return Object.keys(obj1)
+            .concat(Object.keys(obj2))
+            .every((key) => {
+                return obj1[key] === obj2[key];
+            });
+    } else{
+        // When one of PageRefs undefined, return true (both undefined) or false (only one undefined)
+        return pageRef1 === pageRef2;
+    }
 };
 
 /**


### PR DESCRIPTION
Dragging a Component including this PubSub onto the Community Builder Canvas causes an null-pointer on 'cannot find attributes on undefined'; This update prevents the null-pointer, while remaining backward compatible.