### PR TITLE
added connect-src allow rule

### DIFF
--- a/force-app/main/default/cspTrustedSites/googleapis.cspTrustedSite-meta.xml
+++ b/force-app/main/default/cspTrustedSites/googleapis.cspTrustedSite-meta.xml
@@ -3,4 +3,5 @@
     <context>All</context>
     <endpointUrl>https://www.googleapis.com</endpointUrl>
     <isActive>true</isActive>
+    <isApplicableToConnectSrc>true</isApplicableToConnectSrc>
 </CspTrustedSite>


### PR DESCRIPTION
To follow principle of least access, adding the `connect-src` CSP rule to the googleapis CSP rules. 

This replaces PR #302 to make the merge into `prerelease/summer20` easier. 