### PR TITLE
moves data service tab before apex tab

### DIFF
--- a/force-app/main/default/applications/LWC_Recipes.app-meta.xml
+++ b/force-app/main/default/applications/LWC_Recipes.app-meta.xml
@@ -24,8 +24,8 @@
     <label>LWC Recipes</label>
     <navType>Standard</navType>
     <tabs>Hello</tabs>
-    <tabs>Apex</tabs>
     <tabs>Data_Service</tabs>
+    <tabs>Apex</tabs>
     <tabs>standard-Contact</tabs>
     <tabs>Composition</tabs>
     <tabs>Events</tabs>


### PR DESCRIPTION
Resolves issue #158. Reorders app tabs to show **Data Service** first and then **Apex**. 