### PR TITLE
Adding flexipage for permissions recipe

### DIFF
--- a/force-app/main/default/flexipages/Misc_Techniques.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Misc_Techniques.flexipage-meta.xml
@@ -7,6 +7,11 @@
     <flexiPageRegions>
         <itemInstances>
             <componentInstance>
+                <componentName>miscPermissionBasedUI</componentName>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
                 <componentName>miscGetUserId</componentName>
             </componentInstance>
         </itemInstances>


### PR DESCRIPTION
NOT FOR JEST BLITZ

The new custom permission-based component inclusion in the flexipage was missed in the original PR #322. This PR adds the flexipage so it will appear on the UI. 