### PR TITLE
fixed forceignore for README

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -18,4 +18,4 @@ package.xml
 **/__tests__/**
 
 # For the pubsub README
-**/README.md
+**/pubsub/**


### PR DESCRIPTION
Found an issue with .forceignore and the pubsub readme that this fixes. 