### PR TITLE
Add 4 In App Guidance walkthroughs

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ Make sure to start from a brand-new environment to avoid conflicts with previous
     sfdx force:user:permset:assign -n recipes
     ```
 
+1. (Optional) Assign the `Walkthroughs` permission set to the default user.
+
+> Note: this will enable In App Guidance Walkthroughs, allowing you to be taken through a guided tour of the sample app.
+
+    ```
+    sfdx force:user:permset:assign -n Walkthroughs
+    ```
+
 1. Import some sample data.
 
     ```

--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -2,6 +2,7 @@
     "orgName": "LWC Recipes",
     "edition": "Developer",
     "hasSampleData": false,
+    "features": ["Walkthroughs"],
     "settings": {
         "lightningExperienceSettings": {
             "enableS1DesktopEnabled": true
@@ -13,6 +14,10 @@
         },
         "mobileSettings": {
             "enableS1EncryptedStoragePref2": false
+        },
+        "userEngagementSettings": {
+            "enableOrchestrationInSandbox": true,
+            "enableShowSalesforceUserAssist": false
         }
     }
 }

--- a/force-app/main/default/lightningOnboardingConfigs/LightningOnboardingConfig.lightningOnboardingConfig-meta.xml
+++ b/force-app/main/default/lightningOnboardingConfigs/LightningOnboardingConfig.lightningOnboardingConfig-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningOnboardingConfig
+    xmlns="http://soap.sforce.com/2006/04/metadata"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+>
+    <collaborationGroup xsi:nil="true" />
+    <feedbackFormDaysFrequency xsi:nil="true" />
+    <isCustom>false</isCustom>
+    <masterLabel>LightningOnboardingConfig</masterLabel>
+    <promptDelayTime>0</promptDelayTime>
+    <sendFeedbackToSalesforce>false</sendFeedbackToSalesforce>
+</LightningOnboardingConfig>

--- a/force-app/main/default/prompts/CompositionWalkthrough.prompt-meta.xml
+++ b/force-app/main/default/prompts/CompositionWalkthrough.prompt-meta.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Prompt xmlns="http://soap.sforce.com/2006/04/metadata">
+    <masterLabel>Composition Walkthrough</masterLabel>
+    <promptVersions>
+        <body
+        >Larger components are made of more atomic components. This is called &quot;composition&quot;. This page has several basic composition examples. Search in the CompositionContactSearch component and notice the child components. Then click &quot;Next&quot;.</body>
+        <delayDays>1</delayDays>
+        <description
+        >Walkthrough of composition, events, navigation, aura interop, and message service.</description>
+        <dismissButtonLabel>Close</dismissButtonLabel>
+        <displayPosition>TopCenter</displayPosition>
+        <displayType>FloatingPanel</displayType>
+        <isPublished>true</isPublished>
+        <masterLabel>Composition Walkthrough Step 1</masterLabel>
+        <publishedDate>2020-08-06</publishedDate>
+        <shouldDisplayActionButton>false</shouldDisplayActionButton>
+        <shouldIgnoreGlobalDelay>false</shouldIgnoreGlobalDelay>
+        <startDate>2020-08-06</startDate>
+        <stepNumber>1</stepNumber>
+        <targetAppDeveloperName>LWC_Recipes</targetAppDeveloperName>
+        <targetPageKey1>Composition</targetPageKey1>
+        <targetPageType>standard__navItemPage</targetPageType>
+        <timesToDisplay>1</timesToDisplay>
+        <title>Components in components</title>
+        <userAccess>Everyone</userAccess>
+        <userProfileAccess>Everyone</userProfileAccess>
+        <versionNumber>1</versionNumber>
+    </promptVersions>
+    <promptVersions>
+        <body
+        >Child components fire standard and custom DOM events to notify their parents of changes.  Click on a contact in one of the lists to see this in action. Then click &quot;Next&quot;.</body>
+        <dismissButtonLabel>Close</dismissButtonLabel>
+        <displayPosition>TopLeft</displayPosition>
+        <displayType>FloatingPanel</displayType>
+        <isPublished>false</isPublished>
+        <masterLabel>Composition Walkthrough Step 2</masterLabel>
+        <shouldDisplayActionButton>false</shouldDisplayActionButton>
+        <shouldIgnoreGlobalDelay>false</shouldIgnoreGlobalDelay>
+        <stepNumber>2</stepNumber>
+        <targetAppDeveloperName>LWC_Recipes</targetAppDeveloperName>
+        <targetPageKey1>Events</targetPageKey1>
+        <targetPageType>standard__navItemPage</targetPageType>
+        <title>From Child to Parent</title>
+        <userAccess>Everyone</userAccess>
+        <userProfileAccess>Everyone</userProfileAccess>
+        <versionNumber>1</versionNumber>
+    </promptVersions>
+    <promptVersions>
+        <body
+        >This page demonstrates how a parent component can pass data to a child component&apos;s public properties. Try changing the &quot;Percentage&quot; in the ApiProperty component to see this. Then click &quot;Next&quot;.</body>
+        <dismissButtonLabel>Close</dismissButtonLabel>
+        <displayPosition>TopCenter</displayPosition>
+        <displayType>FloatingPanel</displayType>
+        <isPublished>false</isPublished>
+        <masterLabel>Composition Walkthrough Step 3</masterLabel>
+        <shouldDisplayActionButton>false</shouldDisplayActionButton>
+        <shouldIgnoreGlobalDelay>false</shouldIgnoreGlobalDelay>
+        <stepNumber>3</stepNumber>
+        <targetAppDeveloperName>LWC_Recipes</targetAppDeveloperName>
+        <targetPageKey1>Parent_to_Child</targetPageKey1>
+        <targetPageType>standard__navItemPage</targetPageType>
+        <title>From Parent to Child</title>
+        <userAccess>Everyone</userAccess>
+        <userProfileAccess>Everyone</userProfileAccess>
+        <versionNumber>1</versionNumber>
+    </promptVersions>
+    <promptVersions>
+        <body
+        >&lt;p&gt;The navigation service has many ways to navigate to different parts of the Salesforce UI. Click &quot;Go to New Contact&quot; on the NavToNewRecord component. Create a new contact, (or dismiss the popup). Then click &quot;Next&quot;.&lt;/p&gt;</body>
+        <displayPosition>BottomCenter</displayPosition>
+        <displayType>DockedComposer</displayType>
+        <header>Getting Around the UI</header>
+        <isPublished>false</isPublished>
+        <masterLabel>Composition Walkthrough Step 4</masterLabel>
+        <shouldDisplayActionButton>false</shouldDisplayActionButton>
+        <shouldIgnoreGlobalDelay>false</shouldIgnoreGlobalDelay>
+        <stepNumber>4</stepNumber>
+        <targetAppDeveloperName>LWC_Recipes</targetAppDeveloperName>
+        <targetPageKey1>Navigation</targetPageKey1>
+        <targetPageType>standard__navItemPage</targetPageType>
+        <title>Navigation</title>
+        <userAccess>Everyone</userAccess>
+        <userProfileAccess>Everyone</userProfileAccess>
+        <versionNumber>1</versionNumber>
+    </promptVersions>
+    <promptVersions>
+        <body
+        >You can also add Lightning Web Components as children to your Aura components. Click the list to see how a LWC child component can interact with a parent Aura component. Then click &quot;Next&quot;.</body>
+        <dismissButtonLabel>Close</dismissButtonLabel>
+        <displayPosition>BottomLeft</displayPosition>
+        <displayType>FloatingPanel</displayType>
+        <isPublished>false</isPublished>
+        <masterLabel>Composition Walkthrough Step 5</masterLabel>
+        <shouldDisplayActionButton>false</shouldDisplayActionButton>
+        <shouldIgnoreGlobalDelay>false</shouldIgnoreGlobalDelay>
+        <stepNumber>5</stepNumber>
+        <targetAppDeveloperName>LWC_Recipes</targetAppDeveloperName>
+        <targetPageKey1>Aura_Interoperability</targetPageKey1>
+        <targetPageType>standard__navItemPage</targetPageType>
+        <title>LWC in Aura</title>
+        <userAccess>Everyone</userAccess>
+        <userProfileAccess>Everyone</userProfileAccess>
+        <versionNumber>1</versionNumber>
+    </promptVersions>
+    <promptVersions>
+        <body
+        >Lightning Message Service is a client-side service that sends messages across DOM branches. LMS works seamlessly between LWC, Aura, and Visualforce. Click a contact in the list to see it appear in a subscriber, then click &quot;Next&quot;.</body>
+        <dismissButtonLabel>Close</dismissButtonLabel>
+        <displayPosition>TopCenter</displayPosition>
+        <displayType>FloatingPanel</displayType>
+        <isPublished>false</isPublished>
+        <masterLabel>Composition Walkthrough Step 6</masterLabel>
+        <shouldDisplayActionButton>false</shouldDisplayActionButton>
+        <shouldIgnoreGlobalDelay>false</shouldIgnoreGlobalDelay>
+        <stepNumber>6</stepNumber>
+        <targetAppDeveloperName>LWC_Recipes</targetAppDeveloperName>
+        <targetPageKey1>Message_Service</targetPageKey1>
+        <targetPageType>standard__navItemPage</targetPageType>
+        <title>Lightning Message Service</title>
+        <userAccess>Everyone</userAccess>
+        <userProfileAccess>Everyone</userProfileAccess>
+        <versionNumber>1</versionNumber>
+    </promptVersions>
+    <promptVersions>
+        <actionButtonLabel>Next Tour</actionButtonLabel>
+        <actionButtonLink>/lightning/n/X3rd_Party_Libs</actionButtonLink>
+        <body
+        >&lt;p&gt;This tour walked through the key features that bring single components together into a whole user interface, including composition, events, navigation, and cross-DOM messaging. You also saw how your Aura components can make use of new Lightning Web Components.&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;There&apos;s one more tour available in this app. Click &quot;Next Tour&quot; to check it out.&lt;/p&gt;</body>
+        <displayPosition>BottomCenter</displayPosition>
+        <displayType>DockedComposer</displayType>
+        <header>Building your UI</header>
+        <isPublished>false</isPublished>
+        <masterLabel>Composition Walkthrough Step 7</masterLabel>
+        <shouldDisplayActionButton>true</shouldDisplayActionButton>
+        <shouldIgnoreGlobalDelay>false</shouldIgnoreGlobalDelay>
+        <stepNumber>7</stepNumber>
+        <targetAppDeveloperName>LWC_Recipes</targetAppDeveloperName>
+        <targetPageKey1>Message_Service</targetPageKey1>
+        <targetPageType>standard__navItemPage</targetPageType>
+        <title>Composition, Events, and Messaging</title>
+        <userAccess>Everyone</userAccess>
+        <userProfileAccess>Everyone</userProfileAccess>
+        <versionNumber>1</versionNumber>
+    </promptVersions>
+</Prompt>

--- a/force-app/main/default/prompts/DataWalkthrough.prompt-meta.xml
+++ b/force-app/main/default/prompts/DataWalkthrough.prompt-meta.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Prompt xmlns="http://soap.sforce.com/2006/04/metadata">
+    <masterLabel>Data Walkthrough</masterLabel>
+    <promptVersions>
+        <body
+        >Lightning Data Service (LDS) allows interaction with the database without writing any server-side (Apex) code. Create a record using the LdsCreate component to see it at work. Then click &quot;Next&quot;.</body>
+        <delayDays>1</delayDays>
+        <description
+        >Walkthrough for data through Lightning Data Service and Apex.</description>
+        <dismissButtonLabel>Close</dismissButtonLabel>
+        <displayPosition>TopLeft</displayPosition>
+        <displayType>FloatingPanel</displayType>
+        <isPublished>true</isPublished>
+        <masterLabel>Data Walkthrough Step 1</masterLabel>
+        <publishedDate>2020-08-06</publishedDate>
+        <shouldDisplayActionButton>false</shouldDisplayActionButton>
+        <shouldIgnoreGlobalDelay>false</shouldIgnoreGlobalDelay>
+        <startDate>2020-08-06</startDate>
+        <stepNumber>1</stepNumber>
+        <targetAppDeveloperName>LWC_Recipes</targetAppDeveloperName>
+        <targetPageKey1>Data_Service</targetPageKey1>
+        <targetPageType>standard__navItemPage</targetPageType>
+        <timesToDisplay>1</timesToDisplay>
+        <title>Data Access</title>
+        <userAccess>Everyone</userAccess>
+        <userProfileAccess>Everyone</userProfileAccess>
+        <versionNumber>1</versionNumber>
+    </promptVersions>
+    <promptVersions>
+        <body
+        >LDS also has built in features that make implementing components for record pages simple. Click between the &quot;Dynamic Schema&quot; and &quot;Static Schema&quot; tabs 👉 to see example components for record pages. Then click &quot;Next&quot;.</body>
+        <dismissButtonLabel>Close</dismissButtonLabel>
+        <displayPosition>TopCenter</displayPosition>
+        <displayType>FloatingPanel</displayType>
+        <isPublished>false</isPublished>
+        <masterLabel>Data Walkthrough Step 2</masterLabel>
+        <shouldDisplayActionButton>false</shouldDisplayActionButton>
+        <shouldIgnoreGlobalDelay>false</shouldIgnoreGlobalDelay>
+        <stepNumber>2</stepNumber>
+        <targetAppDeveloperName>LWC_Recipes</targetAppDeveloperName>
+        <targetPageKey1>Contact</targetPageKey1>
+        <targetPageKey2>view</targetPageKey2>
+        <targetPageType>standard__recordPage</targetPageType>
+        <title>On the record page</title>
+        <userAccess>Everyone</userAccess>
+        <userProfileAccess>Everyone</userProfileAccess>
+        <versionNumber>1</versionNumber>
+    </promptVersions>
+    <promptVersions>
+        <body
+        >When LDS won&apos;t work, these Apex examples will show you how to fall back to Apex. Click on &quot;Load Contacts&quot; and perform a search, then click &quot;Next&quot;.</body>
+        <dismissButtonLabel>Close</dismissButtonLabel>
+        <displayPosition>BottomCenter</displayPosition>
+        <displayType>FloatingPanel</displayType>
+        <isPublished>false</isPublished>
+        <masterLabel>Data Walkthrough Step 3</masterLabel>
+        <shouldDisplayActionButton>false</shouldDisplayActionButton>
+        <shouldIgnoreGlobalDelay>false</shouldIgnoreGlobalDelay>
+        <stepNumber>3</stepNumber>
+        <targetAppDeveloperName>LWC_Recipes</targetAppDeveloperName>
+        <targetPageKey1>Apex</targetPageKey1>
+        <targetPageType>standard__navItemPage</targetPageType>
+        <title>Data Through Apex</title>
+        <userAccess>Everyone</userAccess>
+        <userProfileAccess>Everyone</userProfileAccess>
+        <versionNumber>1</versionNumber>
+    </promptVersions>
+    <promptVersions>
+        <body
+        >The wire service is critical for using both LDS and Apex. But the wire service can access other org features and data. Click &quot;Get Object Info&quot; to retrieve describe information about the Account object. Then click &quot;Next&quot;.</body>
+        <dismissButtonLabel>Close</dismissButtonLabel>
+        <displayPosition>TopRight</displayPosition>
+        <displayType>FloatingPanel</displayType>
+        <isPublished>false</isPublished>
+        <masterLabel>Data Walkthrough Step 4</masterLabel>
+        <shouldDisplayActionButton>false</shouldDisplayActionButton>
+        <shouldIgnoreGlobalDelay>false</shouldIgnoreGlobalDelay>
+        <stepNumber>4</stepNumber>
+        <targetAppDeveloperName>LWC_Recipes</targetAppDeveloperName>
+        <targetPageKey1>Wire</targetPageKey1>
+        <targetPageType>standard__navItemPage</targetPageType>
+        <title>Wiring It Up</title>
+        <userAccess>Everyone</userAccess>
+        <userProfileAccess>Everyone</userProfileAccess>
+        <versionNumber>1</versionNumber>
+    </promptVersions>
+    <promptVersions>
+        <actionButtonLabel>Next Tour</actionButtonLabel>
+        <actionButtonLink>/lightning/n/Composition</actionButtonLink>
+        <body
+        >&lt;p&gt;In this tour, you got to see how Lightning Data Service and Apex both allow you to interact with data on the server. You also learned how the wire service works with LDS, Apex, and other important data on the server.&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;The next tour will take you through features that allow you to pull together many components to compose your UI. You&apos;ll also see how those components can interact with other components in Lightning Experience, including standard navigation, Aura components, and Visualforce pages.&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;To go to the next walkthrough, click &quot;Next Tour&quot;.&lt;/p&gt;</body>
+        <displayPosition>BottomCenter</displayPosition>
+        <displayType>DockedComposer</displayType>
+        <header>Interacting with the server</header>
+        <isPublished>false</isPublished>
+        <masterLabel>Data Walkthrough Step 5</masterLabel>
+        <shouldDisplayActionButton>true</shouldDisplayActionButton>
+        <shouldIgnoreGlobalDelay>false</shouldIgnoreGlobalDelay>
+        <stepNumber>5</stepNumber>
+        <targetAppDeveloperName>LWC_Recipes</targetAppDeveloperName>
+        <targetPageKey1>Wire</targetPageKey1>
+        <targetPageType>standard__navItemPage</targetPageType>
+        <title>Data Service, Apex, and Wire Service</title>
+        <userAccess>Everyone</userAccess>
+        <userProfileAccess>Everyone</userProfileAccess>
+        <versionNumber>1</versionNumber>
+    </promptVersions>
+</Prompt>

--- a/force-app/main/default/prompts/HelloWalkThrough.prompt-meta.xml
+++ b/force-app/main/default/prompts/HelloWalkThrough.prompt-meta.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Prompt xmlns="http://soap.sforce.com/2006/04/metadata">
+    <masterLabel>Hello Walk Through</masterLabel>
+    <promptVersions>
+        <body
+        >Welcome to the Lightning Web Components (LWC) Recipes App. To begin, enter some text into the HelloBinding and HelloExpressions tiles and click &quot;Next&quot;.</body>
+        <delayDays>1</delayDays>
+        <description
+        >Walk through that launches on the Hello tab of LWC Recipes.</description>
+        <dismissButtonLabel>Close</dismissButtonLabel>
+        <displayPosition>TopLeft</displayPosition>
+        <displayType>FloatingPanel</displayType>
+        <isPublished>true</isPublished>
+        <masterLabel>Hello Walk Through Step 1</masterLabel>
+        <publishedDate>2020-08-06</publishedDate>
+        <shouldDisplayActionButton>false</shouldDisplayActionButton>
+        <shouldIgnoreGlobalDelay>false</shouldIgnoreGlobalDelay>
+        <startDate>2020-08-06</startDate>
+        <stepNumber>1</stepNumber>
+        <targetAppDeveloperName>LWC_Recipes</targetAppDeveloperName>
+        <targetPageKey1>Hello</targetPageKey1>
+        <targetPageType>standard__navItemPage</targetPageType>
+        <timesToDisplay>1</timesToDisplay>
+        <title>Hello</title>
+        <userAccess>Everyone</userAccess>
+        <userProfileAccess>Everyone</userProfileAccess>
+        <versionNumber>1</versionNumber>
+    </promptVersions>
+    <promptVersions>
+        <body
+        >Recipes are code samples that illustrate the implementation of a single API or feature. They attempt to use the minimum lines of code required to follow best practices.</body>
+        <dismissButtonLabel>Close</dismissButtonLabel>
+        <displayPosition>TopCenter</displayPosition>
+        <displayType>FloatingPanel</displayType>
+        <isPublished>false</isPublished>
+        <masterLabel>Hello Walk Through Step 2</masterLabel>
+        <shouldDisplayActionButton>false</shouldDisplayActionButton>
+        <shouldIgnoreGlobalDelay>false</shouldIgnoreGlobalDelay>
+        <stepNumber>2</stepNumber>
+        <targetAppDeveloperName>LWC_Recipes</targetAppDeveloperName>
+        <targetPageKey1>Hello</targetPageKey1>
+        <targetPageType>standard__navItemPage</targetPageType>
+        <title>What are recipes?</title>
+        <userAccess>Everyone</userAccess>
+        <userProfileAccess>Everyone</userProfileAccess>
+        <versionNumber>1</versionNumber>
+    </promptVersions>
+    <promptVersions>
+        <body
+        >The recipes application tabs above ☝️ identify the features explored on each tab. You&apos;ll find other walk throughs in other tabs.</body>
+        <dismissButtonLabel>Close</dismissButtonLabel>
+        <displayPosition>TopLeft</displayPosition>
+        <displayType>FloatingPanel</displayType>
+        <isPublished>false</isPublished>
+        <masterLabel>Hello Walk Through Step 3</masterLabel>
+        <shouldDisplayActionButton>false</shouldDisplayActionButton>
+        <shouldIgnoreGlobalDelay>false</shouldIgnoreGlobalDelay>
+        <stepNumber>3</stepNumber>
+        <targetAppDeveloperName>LWC_Recipes</targetAppDeveloperName>
+        <targetPageKey1>Hello</targetPageKey1>
+        <targetPageType>standard__navItemPage</targetPageType>
+        <title>Recipes tabs</title>
+        <userAccess>Everyone</userAccess>
+        <userProfileAccess>Everyone</userProfileAccess>
+        <versionNumber>1</versionNumber>
+    </promptVersions>
+    <promptVersions>
+        <body
+        >Since recipes are code samples, finding the code is simple. Click the &quot;View Source&quot; link on any recipe card and you will be taken to it&apos;s location on GitHub. (Just don&apos;t forget to come back!)</body>
+        <dismissButtonLabel>Close</dismissButtonLabel>
+        <displayPosition>BottomLeft</displayPosition>
+        <displayType>FloatingPanel</displayType>
+        <isPublished>false</isPublished>
+        <masterLabel>Hello Walk Through Step 4</masterLabel>
+        <shouldDisplayActionButton>false</shouldDisplayActionButton>
+        <shouldIgnoreGlobalDelay>false</shouldIgnoreGlobalDelay>
+        <stepNumber>4</stepNumber>
+        <targetAppDeveloperName>LWC_Recipes</targetAppDeveloperName>
+        <targetPageKey1>Composition</targetPageKey1>
+        <targetPageType>standard__navItemPage</targetPageType>
+        <title>Easy access to source</title>
+        <userAccess>Everyone</userAccess>
+        <userProfileAccess>Everyone</userProfileAccess>
+        <versionNumber>1</versionNumber>
+    </promptVersions>
+    <promptVersions>
+        <actionButtonLabel>Next Tour</actionButtonLabel>
+        <actionButtonLink>/lightning/n/Data_Service</actionButtonLink>
+        <body
+        >&lt;p&gt;Congrats! You&apos;ve finished the first walkthrough tour of &lt;b&gt;LWC Recipes&lt;/b&gt;. If you want to learn more about all the recipes in this app, you can click &quot;Next Tour&quot; below, and you&apos;ll move on to another. &lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;In all there are four walkthroughs in LWC Recipes, each to give you a taste of different types of recipes in this app. &lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;Of course, you can also click &quot;Finish&quot;, and jump right to a specific recipe tab. &lt;/p&gt;</body>
+        <displayPosition>BottomCenter</displayPosition>
+        <displayType>DockedComposer</displayType>
+        <header>You&apos;re Just Getting Started</header>
+        <isPublished>false</isPublished>
+        <masterLabel>Hello Walk Through Step 5</masterLabel>
+        <shouldDisplayActionButton>true</shouldDisplayActionButton>
+        <shouldIgnoreGlobalDelay>false</shouldIgnoreGlobalDelay>
+        <stepNumber>5</stepNumber>
+        <targetAppDeveloperName>LWC_Recipes</targetAppDeveloperName>
+        <targetPageKey1>Hello</targetPageKey1>
+        <targetPageType>standard__navItemPage</targetPageType>
+        <title>So much more to see!</title>
+        <userAccess>Everyone</userAccess>
+        <userProfileAccess>Everyone</userProfileAccess>
+        <versionNumber>1</versionNumber>
+    </promptVersions>
+</Prompt>

--- a/force-app/main/default/prompts/Miscand3rdPartyWalkthrough.prompt-meta.xml
+++ b/force-app/main/default/prompts/Miscand3rdPartyWalkthrough.prompt-meta.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Prompt xmlns="http://soap.sforce.com/2006/04/metadata">
+    <masterLabel>Misc and 3rd Party Walkthrough</masterLabel>
+    <promptVersions>
+        <body
+        >Third party libraries are often critical to get just the right functionality for your app. This page demonstrates several popular libraries in LWC. Change the date on the LibsMomentjs component. Then click &quot;Next&quot;.</body>
+        <delayDays>1</delayDays>
+        <description
+        >Walkthrough of 3rd Party JS libs and Misc recipes.</description>
+        <dismissButtonLabel>Close</dismissButtonLabel>
+        <displayPosition>TopCenter</displayPosition>
+        <displayType>FloatingPanel</displayType>
+        <isPublished>true</isPublished>
+        <masterLabel>Misc and 3rd Party Walkthrough Step 1</masterLabel>
+        <publishedDate>2020-08-06</publishedDate>
+        <shouldDisplayActionButton>false</shouldDisplayActionButton>
+        <shouldIgnoreGlobalDelay>false</shouldIgnoreGlobalDelay>
+        <startDate>2020-08-06</startDate>
+        <stepNumber>1</stepNumber>
+        <targetAppDeveloperName>LWC_Recipes</targetAppDeveloperName>
+        <targetPageKey1>X3rd_Party_Libs</targetPageKey1>
+        <targetPageType>standard__navItemPage</targetPageType>
+        <timesToDisplay>1</timesToDisplay>
+        <title>3rd Party Libraries</title>
+        <userAccess>Everyone</userAccess>
+        <userProfileAccess>Everyone</userProfileAccess>
+        <versionNumber>1</versionNumber>
+    </promptVersions>
+    <promptVersions>
+        <body
+        >This page demonstrates a number of other important features in LWC. Even though they don&apos;t have a common theme, don&apos;t overlook this page! Click &quot;Search&quot; in the MiscRestApiCall component. Then click &quot;Next&quot;.</body>
+        <dismissButtonLabel>Close</dismissButtonLabel>
+        <displayPosition>TopRight</displayPosition>
+        <displayType>FloatingPanel</displayType>
+        <isPublished>false</isPublished>
+        <masterLabel>Misc and 3rd Party Walkthrough Step 2</masterLabel>
+        <shouldDisplayActionButton>false</shouldDisplayActionButton>
+        <shouldIgnoreGlobalDelay>false</shouldIgnoreGlobalDelay>
+        <stepNumber>2</stepNumber>
+        <targetAppDeveloperName>LWC_Recipes</targetAppDeveloperName>
+        <targetPageKey1>Misc_Techniques</targetPageKey1>
+        <targetPageType>standard__navItemPage</targetPageType>
+        <title>All the Things</title>
+        <userAccess>Everyone</userAccess>
+        <userProfileAccess>Everyone</userProfileAccess>
+        <versionNumber>1</versionNumber>
+    </promptVersions>
+    <promptVersions>
+        <actionButtonLabel>GitHub</actionButtonLabel>
+        <actionButtonLink
+        >https://github.com/trailheadapps/lwc-recipes</actionButtonLink>
+        <body
+        >&lt;p&gt;You&apos;ve now completed your harbor tour of the LWC Recipes sample app.&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;We hope you enjoyed the trip and that you feel empowered to build something with LWC.&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;If you have an idea for a recipe, visit the GitHub repo and share with us using GitHub issues. Remember, LWC recipes are meant to highlight granular LWC-specific APIs and features using a minimal amount of code.&lt;/p&gt;</body>
+        <displayPosition>BottomCenter</displayPosition>
+        <displayType>DockedComposer</displayType>
+        <header>Wrapping it up</header>
+        <isPublished>false</isPublished>
+        <masterLabel>Misc and 3rd Party Walkthrough Step 3</masterLabel>
+        <shouldDisplayActionButton>true</shouldDisplayActionButton>
+        <shouldIgnoreGlobalDelay>false</shouldIgnoreGlobalDelay>
+        <stepNumber>3</stepNumber>
+        <targetAppDeveloperName>LWC_Recipes</targetAppDeveloperName>
+        <targetPageKey1>Misc_Techniques</targetPageKey1>
+        <targetPageType>standard__navItemPage</targetPageType>
+        <title>Your Tour Is Complete</title>
+        <userAccess>Everyone</userAccess>
+        <userProfileAccess>Everyone</userProfileAccess>
+        <versionNumber>1</versionNumber>
+    </promptVersions>
+</Prompt>


### PR DESCRIPTION
### What does this PR do?
Adds 3 in-app guidance walkthroughs to the sample app

### What issues does this PR fix or reference?

## The PR fulfills these requirements:

[ ] Tests for the proposed changes have been added/updated.
[X] Code linting and formatting was performed.

### Functionality Before

No Walkthroughs

### Functionality After

4 Walkthroughs

- Hello: welcome to the sample app. What to look for, how to find code, and interact with the hello page
- Data: Covers LDS, Apex, and Wire
- Composition: Covers composition, child-to-parent, parent-to-child, navigation, aura interop, and LMS
- 3rd Part and Misc: Covers those two tabs