### PR TITLE
removed old work.com quick action

### DIFF
--- a/force-app/main/default/layouts/Account-Account Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Account-Account Layout.layout-meta.xml
@@ -179,9 +179,6 @@
             <quickActionName>NewEvent</quickActionName>
         </quickActionListItems>
         <quickActionListItems>
-            <quickActionName>FeedItem.RypplePost</quickActionName>
-        </quickActionListItems>
-        <quickActionListItems>
             <quickActionName>FeedItem.LinkPost</quickActionName>
         </quickActionListItems>
         <quickActionListItems>


### PR DESCRIPTION
addresses issue #376 to remove EOL Rypple quick action from account layout. 