### PR TITLE
Add apex exec perms to permset

### DIFF
--- a/force-app/main/default/permissionsets/recipes.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/recipes.permissionset-meta.xml
@@ -4,6 +4,26 @@
         <application>LWC_Recipes</application>
         <visible>true</visible>
     </applicationVisibilities>
+    <classAccesses>
+        <apexClass>AccountController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>ApexTypesController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>ContactController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>CustomWrapper</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>LMSVisualforceController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
     <fieldPermissions>
         <editable>true</editable>
         <field>Account.AreaNumber__c</field>


### PR DESCRIPTION
### What does this PR do?
Addresses apex execution permission requirements added in the Winter 21 critical [release](https://releasenotes.docs.salesforce.com/en-us/summer20/release-notes/rn_lc_restrict_apex_authenticated_users.htm) requiring executing user to have execution access to any apex classes via either profile or permission set. This PR adds those permissions to the `recipes` permission set. 

### What issues does this PR fix or reference?

#<Insert GitHub Issue>

## The PR fulfills these requirements:

[X] Tests for the proposed changes have been added/updated.
[X] Code linting and formatting was performed.

### Functionality Before

<insert gif and/or summary>

### Functionality After

<insert gif and/or summary>
