### PR TITLE
Pc/prerelease/modal fix

### DIFF
--- a/force-app/main/default/lwc/modal/modal.js
+++ b/force-app/main/default/lwc/modal/modal.js
@@ -32,11 +32,21 @@ export default class Modal extends LightningElement {
     }
 
     handleSlotTaglineChange() {
+        // Only needed in "show" state. If hiding, we're removing from DOM anyway
+        // Added to address Issue #344 where querySelector would intermittently return null element on hide
+        if (this.showModal === false) {
+            return;
+        }
         const taglineEl = this.template.querySelector('p');
         taglineEl.classList.remove(CSS_CLASS);
     }
 
     handleSlotFooterChange() {
+        // Only needed in "show" state. If hiding, we're removing from DOM anyway
+        // Added to address Issue #344 where querySelector would intermittently return null element on hide
+        if (this.showModal === false) {
+            return;
+        }
         const footerEl = this.template.querySelector('footer');
         footerEl.classList.remove(CSS_CLASS);
     }


### PR DESCRIPTION
### What does this PR do?
Addresses issue #344. In some production environments, the modal hide produces an error when the slot change handler returns a null element from `querySelector`. This logic is only required on modal show, so this solution ensures we don't invoke `querySelector` when hide triggers the slot change event. 

### What issues does this PR fix or reference?

#344 

## The PR fulfills these requirements:

[X] Tests for the proposed changes have been added/updated.
[X] Code linting and formatting was performed.

