### PR TITLE
Added CodeTour as a recommended VS Code extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,5 @@ ehthumbs.db
 $RECYCLE.BIN/
 
 # VS Code project settings
-.vscode/
+.vscode/*
+!.vscode/extensions.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+     "vsls-contrib.codetour"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ A collection of easy-to-digest code examples for Lightning Web Components. Each 
 
 -   [Optional installation instructions](#optional-installation-instructions)
 
+-   [Code tours](#code-tours)
+
 ## Installing the app using a Scratch Org
 
 1. Set up your environment. Follow the steps in the [Quick Start: Lightning Web Components](https://trailhead.salesforce.com/content/learn/projects/quick-start-lightning-web-components/) Trailhead project. The steps include:
@@ -201,3 +203,7 @@ Prettier and ESLint will now run automatically every time you commit changes. Th
 npm run lint:lwc
 npm run prettier
 ```
+
+## Code Tours
+
+Code Tours are guided walkthroughs that will help you understand the app code better. To be able to run them, install the [CodeTour VSCode extension](https://marketplace.visualstudio.com/items?itemName=vsls-contrib.codetour).


### PR DESCRIPTION
Added CodeTour as a recommended VS Code extension. This brings up a prompt that suggest installing the extension when the user imports the project.
If users don't have the extension, our tours are pretty useless :)