### PR TITLE
Return field value for relationship fields

### DIFF
--- a/force-app/test/jest-mocks/lightning/uiRecordApi.js
+++ b/force-app/test/jest-mocks/lightning/uiRecordApi.js
@@ -24,10 +24,13 @@ export const getFieldValue = jest.fn((data, fieldReference) => {
                 return fieldData.value;
             }
         } else {
-            const relationshipField = data.fields[fields[0]];
-            const fieldData = relationshipField.value.fields[fields[1]];
-            if (fieldData) {
-                return fieldData.value;
+            const field = data.fields[fields[0]];
+            if (!field.value.fields) {
+                return field.value;
+            }
+            const relationshipField = field.value.fields[fields[1]];
+            if (relationshipField) {
+                return relationshipField.value;
             }
         }
         return null;

--- a/force-app/test/jest-mocks/lightning/uiRecordApi.js
+++ b/force-app/test/jest-mocks/lightning/uiRecordApi.js
@@ -24,8 +24,9 @@ export const getFieldValue = jest.fn((data, fieldReference) => {
                 return fieldData.value;
             }
         } else {
-            const fieldData = fields.reduce((o, i) => o[i], data.fields);
-            if (fieldData && fieldData.value) {
+            const relationshipField = data.fields[fields[0]];
+            const fieldData = relationshipField.value.fields[fields[1]];
+            if (fieldData) {
                 return fieldData.value;
             }
         }


### PR DESCRIPTION
The mock was not taking into account relationship field values e.g. Brand__r.Name__c

### What does this PR do?
Updates the uiRecordApi getFieldValue mock

### What issues does this PR fix or reference?
Relationship fields not returning a field value when using `getFieldValue`

#<Insert GitHub Issue>

## The PR fulfills these requirements:

[ ] Tests for the proposed changes have been added/updated.
[ x] Code linting and formatting was performed.

### Functionality Before

Method would only return field values at the top level, meaning relationship fields always returned `null`

### Functionality After

Method now returns the relationship field value in the mock
