### PR TITLE
Update apex complex params recipes to use dual-listbox

### DIFF
--- a/force-app/main/default/classes/CustomWrapper.cls
+++ b/force-app/main/default/classes/CustomWrapper.cls
@@ -1,16 +1,8 @@
 public with sharing class CustomWrapper {
-    @TestVisible
-    class InnerWrapper {
-        @AuraEnabled
-        public Integer someInnerInteger { get; set; }
-        @AuraEnabled
-        public String someInnerString { get; set; }
-    }
-
     @AuraEnabled
     public Integer someInteger { get; set; }
     @AuraEnabled
     public String someString { get; set; }
     @AuraEnabled
-    public List<InnerWrapper> someList { get; set; }
+    public List<Object> someList { get; set; }
 }

--- a/force-app/main/default/flexipages/Apex.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Apex.flexipage-meta.xml
@@ -15,6 +15,11 @@
                 <componentName>apexWireMethodToFunction</componentName>
             </componentInstance>
         </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentName>apexStaticSchema</componentName>
+            </componentInstance>
+        </itemInstances>
         <name>region2</name>
         <type>Region</type>
     </flexiPageRegions>
@@ -26,7 +31,13 @@
         </itemInstances>
         <itemInstances>
             <componentInstance>
-                <componentName>apexStaticSchema</componentName>
+                <componentName>apexImperativeMethodWithParams</componentName>
+            </componentInstance>
+        </itemInstances>
+                <itemInstances>
+            <componentInstance>
+                <componentName
+                >apexImperativeMethodWithComplexParams</componentName>
             </componentInstance>
         </itemInstances>
         <name>region3</name>
@@ -40,18 +51,7 @@
         </itemInstances>
         <itemInstances>
             <componentInstance>
-                <componentName>apexImperativeMethodWithParams</componentName>
-            </componentInstance>
-        </itemInstances>
-        <itemInstances>
-            <componentInstance>
                 <componentName>apexWireMethodWithComplexParams</componentName>
-            </componentInstance>
-        </itemInstances>
-        <itemInstances>
-            <componentInstance>
-                <componentName
-                >apexImperativeMethodWithComplexParams</componentName>
             </componentInstance>
         </itemInstances>
         <name>region4</name>

--- a/force-app/main/default/lwc/apexImperativeMethodWithComplexParams/__tests__/apexImperativeMethodWithComplexParams.test.js
+++ b/force-app/main/default/lwc/apexImperativeMethodWithComplexParams/__tests__/apexImperativeMethodWithComplexParams.test.js
@@ -18,9 +18,9 @@ const APEX_PARAMETER = {
     someString: 'This is a string',
     someInteger: 20,
     someList: [
-        { someInnerString: 'This is a string', someInnerInteger: 20 },
-        { someInnerString: 'This is a string', someInnerInteger: 20 },
-        { someInnerString: 'This is a string', someInnerInteger: 20 }
+        { value: '1', label: 'Option 1' },
+        { value: '2', label: 'Option 2' },
+        { value: '3', label: 'Option 3' }
     ]
 };
 
@@ -84,9 +84,9 @@ describe('c-apex-imperative-method-with-complex-params', () => {
         inputNumberEl.value = APEX_PARAMETER.someInteger;
         inputNumberEl.dispatchEvent(new CustomEvent('change'));
 
-        // Select input field for simulating list item user input
+        // Select dual listbox for simulating list item user input
         const inputListItemEl = element.shadowRoot.querySelector(
-            'lightning-input[class="list-item-input"]'
+            'lightning-dual-listbox[class="list-input"]'
         );
         inputListItemEl.value = APEX_PARAMETER.someList.length;
         inputListItemEl.dispatchEvent(new CustomEvent('change'));
@@ -135,9 +135,9 @@ describe('c-apex-imperative-method-with-complex-params', () => {
         inputNumberEl.value = APEX_PARAMETER.someInteger;
         inputNumberEl.dispatchEvent(new CustomEvent('change'));
 
-        // Select input field for simulating list item user input
+        // Select dual listbox for simulating list item user input
         const inputListItemEl = element.shadowRoot.querySelector(
-            'lightning-input[class="list-item-input"]'
+            'lightning-dual-listbox[class="list-input"]'
         );
         inputListItemEl.value = APEX_PARAMETER.someList.length;
         inputListItemEl.dispatchEvent(new CustomEvent('change'));

--- a/force-app/main/default/lwc/apexImperativeMethodWithComplexParams/apexImperativeMethodWithComplexParams.html
+++ b/force-app/main/default/lwc/apexImperativeMethodWithComplexParams/apexImperativeMethodWithComplexParams.html
@@ -20,15 +20,16 @@
                 class="number-input"
                 onchange={handleNumberChange}
             ></lightning-input>
-            <lightning-input
-                label="List items"
-                type="number"
-                min="0"
-                max="10"
-                value={listItemValue}
-                class="list-item-input"
-                onchange={handleListItemChange}
-            ></lightning-input>
+            <lightning-dual-listbox
+                label="Build a List"
+                source-label="Available Options"
+                selected-label="Selected Options"
+                options={listOptions}
+                value={defaultOptions}
+                class="list-input"
+                onchange={handleListOptionChange}
+            >
+            </lightning-dual-listbox>
             <br />
             <lightning-button
                 label="Call Apex"

--- a/force-app/main/default/lwc/apexImperativeMethodWithComplexParams/apexImperativeMethodWithComplexParams.js
+++ b/force-app/main/default/lwc/apexImperativeMethodWithComplexParams/apexImperativeMethodWithComplexParams.js
@@ -2,9 +2,17 @@ import { LightningElement } from 'lwc';
 import checkApexTypes from '@salesforce/apex/ApexTypesController.checkApexTypes';
 
 export default class ApexImperativeMethodWithComplexParams extends LightningElement {
-    listItemValue = 4;
+    listValue = [];
     numberValue = 50;
     stringValue = 'Some string';
+
+    listOptions = [
+        { value: '1', label: 'Option 1' },
+        { value: '2', label: 'Option 2' },
+        { value: '3', label: 'Option 3' },
+        { value: '4', label: 'Option 4' },
+        { value: '5', label: 'Option 5' }
+    ];
 
     message;
     error;
@@ -17,8 +25,8 @@ export default class ApexImperativeMethodWithComplexParams extends LightningElem
         this.numberValue = event.target.value;
     }
 
-    handleListItemChange(event) {
-        this.listItemValue = event.target.value;
+    handleListOptionChange(event) {
+        this.listValue = event.detail.value;
     }
 
     handleButtonClick() {
@@ -27,15 +35,8 @@ export default class ApexImperativeMethodWithComplexParams extends LightningElem
         let parameterObject = {
             someString: this.stringValue,
             someInteger: this.numberValue,
-            someList: []
+            someList: this.listValue
         };
-        // Populating a list
-        for (let i = 0; i < this.listItemValue; i++) {
-            parameterObject.someList.push({
-                someInnerString: this.stringValue,
-                someInnerInteger: this.numberValue
-            });
-        }
 
         // Calling the imperative Apex method with the JSON
         // object as parameter.

--- a/force-app/main/default/lwc/apexWireMethodWithComplexParams/__tests__/apexWireMethodWithComplexParams.test.js
+++ b/force-app/main/default/lwc/apexWireMethodWithComplexParams/__tests__/apexWireMethodWithComplexParams.test.js
@@ -15,9 +15,9 @@ const WIRE_INPUT = {
     someString: 'This is a string',
     someInteger: 20,
     someList: [
-        { someInnerString: 'This is a string', someInnerInteger: 20 },
-        { someInnerString: 'This is a string', someInnerInteger: 20 },
-        { someInnerString: 'This is a string', someInnerInteger: 20 }
+        { value: '1', label: 'Option 1' },
+        { value: '2', label: 'Option 2' },
+        { value: '3', label: 'Option 3' }
     ]
 };
 
@@ -92,7 +92,7 @@ describe('c-apex-wire-method-with-complex-params', () => {
 
             // Select input field for simulating list item user input
             const inputListItemEl = element.shadowRoot.querySelector(
-                'lightning-input[class="list-item-input"]'
+                'lightning-dual-listbox[class="list-input"]'
             );
             inputListItemEl.value = WIRE_INPUT.someList.length;
             inputListItemEl.dispatchEvent(new CustomEvent('change'));

--- a/force-app/main/default/lwc/apexWireMethodWithComplexParams/apexWireMethodWithComplexParams.html
+++ b/force-app/main/default/lwc/apexWireMethodWithComplexParams/apexWireMethodWithComplexParams.html
@@ -20,15 +20,16 @@
                 class="number-input"
                 onchange={handleNumberChange}
             ></lightning-input>
-            <lightning-input
-                label="List items"
-                type="number"
-                min="0"
-                max="10"
-                value={listItemValue}
-                class="list-item-input"
-                onchange={handleListItemChange}
-            ></lightning-input>
+            <lightning-dual-listbox
+                id="selectOptions"
+                label="Build a List"
+                source-label="Available Options"
+                selected-label="Selected Options"
+                options={listOptions}
+                class="list-input"
+                onchange={handleListOptionChange}
+            >
+            </lightning-dual-listbox>
             <br />
             <template if:true={apexResponse.data}>
                 <p>{apexResponse.data}</p>

--- a/force-app/main/default/lwc/apexWireMethodWithComplexParams/apexWireMethodWithComplexParams.js
+++ b/force-app/main/default/lwc/apexWireMethodWithComplexParams/apexWireMethodWithComplexParams.js
@@ -2,14 +2,22 @@ import { LightningElement, wire } from 'lwc';
 import checkApexTypes from '@salesforce/apex/ApexTypesController.checkApexTypes';
 
 export default class ApexWireMethodWithComplexParams extends LightningElement {
-    listItemValue = 0;
     numberValue = 50;
     stringValue = 'Some string';
+    listValues = [];
+
+    listOptions = [
+        { value: '1', label: 'Option 1' },
+        { value: '2', label: 'Option 2' },
+        { value: '3', label: 'Option 3' },
+        { value: '4', label: 'Option 4' },
+        { value: '5', label: 'Option 5' }
+    ];
 
     parameterObject = {
         someString: this.stringValue,
         someInteger: this.numberValue,
-        someList: []
+        someList: this.listValues
     };
 
     @wire(checkApexTypes, { wrapper: '$parameterObject' })
@@ -29,17 +37,10 @@ export default class ApexWireMethodWithComplexParams extends LightningElement {
         };
     }
 
-    handleListItemChange(event) {
-        const someList = [];
-        for (let i = 0; i < event.target.value; i++) {
-            someList.push({
-                someInnerString: this.stringValue,
-                someInnerInteger: this.numberValue
-            });
-        }
+    handleListOptionChange(event) {
         this.parameterObject = {
             ...this.parameterObject,
-            someList
+            someList: (this.listValues = event.detail.value)
         };
     }
 }


### PR DESCRIPTION
### What does this PR do?
Updates the Apex complex params recipes to use `lightning-dual-listbox` to create a list instead of using an input field to collect a number that Apex uses to build the list.  

### What issues does this PR fix or reference?
None.

## The PR fulfills these requirements:

[x] Tests for the proposed changes have been added/updated.
[x ] Code linting and formatting was performed.

### Functionality Before

Component used `lightning-input` to capture a number that was passed to Apex to build a list. The user couldn't see that it was a list.

### Functionality After

![wire](https://user-images.githubusercontent.com/32077211/101939843-6c207180-3b9a-11eb-8d3d-08e05c3e38a1.gif)
![imperative](https://user-images.githubusercontent.com/32077211/101939850-6f1b6200-3b9a-11eb-8fef-8593f8ae2a4d.gif)

