### PR TITLE
moved EnableSetPasswordInApi to features

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -2,15 +2,10 @@
     "orgName": "LWC Recipes",
     "edition": "Developer",
     "hasSampleData": false,
-    "features": ["Walkthroughs"],
+    "features": ["Walkthroughs", "EnableSetPasswordInApi"],
     "settings": {
         "lightningExperienceSettings": {
             "enableS1DesktopEnabled": true
-        },
-        "securitySettings": {
-            "passwordPolicies": {
-                "enableSetPasswordInApi": true
-            }
         },
         "mobileSettings": {
             "enableS1EncryptedStoragePref2": false


### PR DESCRIPTION
Move EnableSetPasswordInApi to `features` in the `project-scratch-def.json` file to conform to this being deprecated from `settings` in api v51.0. 