### PR TITLE
chore: Remove uiRecordApi deprecated endpoints

### DIFF
--- a/force-app/test/jest-mocks/lightning/uiRecordApi.js
+++ b/force-app/test/jest-mocks/lightning/uiRecordApi.js
@@ -12,9 +12,7 @@ export const deleteRecord = jest.fn().mockResolvedValue();
 export const generateRecordInputForCreate = jest.fn();
 export const generateRecordInputForUpdate = jest.fn();
 export const createRecordInputFilteredByEditedFields = jest.fn();
-export const getRecordInput = jest.fn();
 export const refresh = jest.fn().mockResolvedValue();
-export const getRecordUi = jest.fn();
 export const getFieldValue = jest.fn((data, fieldReference) => {
     if (data) {
         const fields = fieldReference.fieldApiName.split('.');


### PR DESCRIPTION
### What does this PR do?

Remove `getRecordUI` and `getRecordInput` wire adapters as they are being deprecated by the LDS team. Those API will be removed in 240.