### PR TITLE
messageService Mock: Multiple Channel Subscription Support

### DIFF
--- a/force-app/test/jest-mocks/lightning/messageService.js
+++ b/force-app/test/jest-mocks/lightning/messageService.js
@@ -9,17 +9,15 @@ export const createMessageContext = jest.fn();
 export const MessageContext = jest.fn();
 export const releaseMessageContext = jest.fn();
 export const unsubscribe = jest.fn();
-// LMS stub implementation that lets you test a single message handler on a single channel
-var _messageChannel = null;
-var _messageHandler = null;
+
+// Assigns a handler for each channel subscribed, so that multiple channels can be subscribed to
+// within the same test execution context
+const handlers = {};
 export const publish = jest.fn((messageContext, messageChannel, message) => {
-    if (_messageHandler && _messageChannel === messageChannel) {
-        _messageHandler(message);
-    }
+    handlers[messageChannel]?.(message);
 });
 export const subscribe = jest.fn(
     (messageContext, messageChannel, messageHandler) => {
-        _messageChannel = messageChannel;
-        _messageHandler = messageHandler;
+        handlers[messageChannel] = messageHandler;
     }
 );


### PR DESCRIPTION
Our team recently encountered a situation where one of our developers was calling `subscribe` from the messageService for two different channels. The stub we had copied from this repo currently only supports a single channel's subscription at a time, however, as calling `subscribe` with a different channel simply overwrites the `_messageChannel` and `_messageHandler` variables.

As an example, if we had:
```
connectedCallback() {
    subscribe(
        this.messageContext,
        messageChannelOne,
        messageChannelOneHandler
    );
    subscribe(
        this.messageContext,
        messageChannelTwo,
        messageChannelTwoHandler
    );
}
```

Then in our test, whenever we published an event to the `messageChannelOne` channel, the handler would not be called, so our logic would not run and our test would fail.

This pull request changes the handlers to be an object so that when `subscribe` is called, a new key/value pair is added for each unique channel, where the key is the channel and the value is the single expected handler for that channel. This change resolves the aforementioned issue.

[Optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) is used so that, if `publish` is called for a channel that hasn't been defined yet on the handlers object, no errors will be thrown.