### PR TITLE
 datatableCustomDataType html view-source typo

### DIFF
--- a/force-app/main/default/lwc/datatableCustomDataType/datatableCustomDataType.html
+++ b/force-app/main/default/lwc/datatableCustomDataType/datatableCustomDataType.html
@@ -17,7 +17,7 @@
                 <c-error-panel errors={contacts.error}></c-error-panel>
             </template>
         </div>
-        <c-view-source source="lwc/datataleCustomDataType" slot="footer">
+        <c-view-source source="lwc/datatableCustomDataType" slot="footer">
             Display data in a table with a custom data type: a contact picture
             (see customDataTypes component).
         </c-view-source>


### PR DESCRIPTION
Fix datataleCustomDataType to datatableCustomDataType

### What does this PR do?
Corrects html link to github typo 
### What issues does this PR fix or reference?
#618

## The PR fulfills these requirements:

[ N/A] Tests for the proposed changes have been added/updated.
[ N/A] Code linting and formatting was performed.

### Functionality Before
![image](https://user-images.githubusercontent.com/271131/148317176-08b689eb-0084-46a2-9007-28cc6719e173.png)

![image](https://user-images.githubusercontent.com/271131/148316364-e2658c97-3c98-49f5-a2cb-878e2761f4f3.png)


### Functionality After

![image](https://user-images.githubusercontent.com/271131/148316227-b565d8e3-145d-41b2-8f10-37636810f64d.png)
