### PR TITLE
Make the lightning/navigation mock resettable

### DIFF
--- a/force-app/main/default/lwc/navToChatterHome/__tests__/navToChatterHome.test.js
+++ b/force-app/main/default/lwc/navToChatterHome/__tests__/navToChatterHome.test.js
@@ -11,6 +11,8 @@ describe('c-nav-to-chatter-home', () => {
         while (document.body.firstChild) {
             document.body.removeChild(document.body.firstChild);
         }
+        // Reset the navigation mock between tests
+        jest.clearAllMocks();
     });
 
     // Helper function to wait until the microtask queue is empty. This is needed for promise

--- a/force-app/main/default/lwc/navToFilesHome/__tests__/navToFilesHome.test.js
+++ b/force-app/main/default/lwc/navToFilesHome/__tests__/navToFilesHome.test.js
@@ -11,6 +11,8 @@ describe('c-nav-to-files-home', () => {
         while (document.body.firstChild) {
             document.body.removeChild(document.body.firstChild);
         }
+        // Reset the navigation mock between tests
+        jest.clearAllMocks();
     });
 
     // Helper function to wait until the microtask queue is empty. This is needed for promise

--- a/force-app/main/default/lwc/navToHelloTab/__tests__/navToHelloTab.test.js
+++ b/force-app/main/default/lwc/navToHelloTab/__tests__/navToHelloTab.test.js
@@ -11,6 +11,8 @@ describe('c-nav-to-hello-tab', () => {
         while (document.body.firstChild) {
             document.body.removeChild(document.body.firstChild);
         }
+        // Reset the navigation mock between tests
+        jest.clearAllMocks();
     });
 
     // Helper function to wait until the microtask queue is empty. This is needed for promise

--- a/force-app/main/default/lwc/navToHome/__tests__/navToHome.test.js
+++ b/force-app/main/default/lwc/navToHome/__tests__/navToHome.test.js
@@ -18,6 +18,17 @@ describe('c-nav-to-home', () => {
     async function flushPromises() {
         return Promise.resolve();
     }
+
+    it('navigate mock should be empty (before)', async () => {
+        const element = createElement('c-nav-to-home', {
+            is: NavToHome
+        });
+        document.body.appendChild(element);
+        await flushPromises();
+        const { pageReference } = getNavigateCalledWith();
+        expect(pageReference).toBeUndefined();
+    });
+
     it('navigates to home tab', async () => {
         // Nav param values to test later
         const NAV_TYPE = 'standard__namedPage';
@@ -41,6 +52,20 @@ describe('c-nav-to-home', () => {
         // Verify component called with correct event type and params
         expect(pageReference.type).toBe(NAV_TYPE);
         expect(pageReference.attributes.pageName).toBe(NAV_PAGE);
+    });
+
+    // THIS TEST UNEXPECTEDLY FAILS.
+    it('navigate mock should be empty (after)', async () => {
+        const element = createElement('c-nav-to-home', {
+            is: NavToHome
+        });
+        document.body.appendChild(element);
+        await flushPromises();
+        const { pageReference } = getNavigateCalledWith();
+        expect(pageReference).toBeUndefined();
+        //                    ^ THIS FAILS
+        // expect(received).toBeUndefined()
+        // Received: {"attributes": {"pageName": "home"}, "type": "standard__namedPage"}
     });
 
     it('is accessible', async () => {

--- a/force-app/main/default/lwc/navToHome/__tests__/navToHome.test.js
+++ b/force-app/main/default/lwc/navToHome/__tests__/navToHome.test.js
@@ -20,7 +20,6 @@ describe('c-nav-to-home', () => {
     async function flushPromises() {
         return Promise.resolve();
     }
-
     it('navigates to home tab', async () => {
         // Nav param values to test later
         const NAV_TYPE = 'standard__namedPage';

--- a/force-app/main/default/lwc/navToHome/__tests__/navToHome.test.js
+++ b/force-app/main/default/lwc/navToHome/__tests__/navToHome.test.js
@@ -21,16 +21,6 @@ describe('c-nav-to-home', () => {
         return Promise.resolve();
     }
 
-    it('navigate mock should be empty (before)', async () => {
-        const element = createElement('c-nav-to-home', {
-            is: NavToHome
-        });
-        document.body.appendChild(element);
-        await flushPromises();
-        const { pageReference } = getNavigateCalledWith();
-        expect(pageReference).toBeUndefined();
-    });
-
     it('navigates to home tab', async () => {
         // Nav param values to test later
         const NAV_TYPE = 'standard__namedPage';
@@ -54,20 +44,6 @@ describe('c-nav-to-home', () => {
         // Verify component called with correct event type and params
         expect(pageReference.type).toBe(NAV_TYPE);
         expect(pageReference.attributes.pageName).toBe(NAV_PAGE);
-    });
-
-    // THIS TEST UNEXPECTEDLY FAILS.
-    it('navigate mock should be empty (after)', async () => {
-        const element = createElement('c-nav-to-home', {
-            is: NavToHome
-        });
-        document.body.appendChild(element);
-        await flushPromises();
-        const { pageReference } = getNavigateCalledWith();
-        expect(pageReference).toBeUndefined();
-        //                    ^ THIS FAILS
-        // expect(received).toBeUndefined()
-        // Received: {"attributes": {"pageName": "home"}, "type": "standard__namedPage"}
     });
 
     it('is accessible', async () => {

--- a/force-app/main/default/lwc/navToHome/__tests__/navToHome.test.js
+++ b/force-app/main/default/lwc/navToHome/__tests__/navToHome.test.js
@@ -11,6 +11,8 @@ describe('c-nav-to-home', () => {
         while (document.body.firstChild) {
             document.body.removeChild(document.body.firstChild);
         }
+        // Reset the navigation mock between tests
+        jest.clearAllMocks();
     });
 
     // Helper function to wait until the microtask queue is empty. This is needed for promise

--- a/force-app/main/default/lwc/navToListView/__tests__/navToListView.test.js
+++ b/force-app/main/default/lwc/navToListView/__tests__/navToListView.test.js
@@ -11,6 +11,8 @@ describe('c-nav-to-list-view', () => {
         while (document.body.firstChild) {
             document.body.removeChild(document.body.firstChild);
         }
+        // Reset the navigation mock between tests
+        jest.clearAllMocks();
     });
 
     // Helper function to wait until the microtask queue is empty. This is needed for promise

--- a/force-app/main/default/lwc/navToNewRecord/__tests__/navToNewRecord.test.js
+++ b/force-app/main/default/lwc/navToNewRecord/__tests__/navToNewRecord.test.js
@@ -11,6 +11,8 @@ describe('c-nav-to-new-record', () => {
         while (document.body.firstChild) {
             document.body.removeChild(document.body.firstChild);
         }
+        // Reset the navigation mock between tests
+        jest.clearAllMocks();
     });
 
     // Helper function to wait until the microtask queue is empty. This is needed for promise

--- a/force-app/main/default/lwc/navToNewRecordWithDefaults/__tests__/navToNewRecordWithDefaults.test.js
+++ b/force-app/main/default/lwc/navToNewRecordWithDefaults/__tests__/navToNewRecordWithDefaults.test.js
@@ -13,6 +13,8 @@ describe('c-nav-to-new-record', () => {
         while (document.body.firstChild) {
             document.body.removeChild(document.body.firstChild);
         }
+        // Reset the navigation mock between tests
+        jest.clearAllMocks();
     });
 
     // Helper function to wait until the microtask queue is empty. This is needed for promise

--- a/force-app/main/default/lwc/navToRelatedList/__tests__/navToRelatedList.test.js
+++ b/force-app/main/default/lwc/navToRelatedList/__tests__/navToRelatedList.test.js
@@ -30,6 +30,8 @@ describe('c-nav-to-related-list', () => {
         while (document.body.firstChild) {
             document.body.removeChild(document.body.firstChild);
         }
+        // Reset the navigation mock between tests
+        jest.clearAllMocks();
     });
 
     // Helper function to wait until the microtask queue is empty. This is needed for promise

--- a/force-app/test/jest-mocks/lightning/navigation.js
+++ b/force-app/test/jest-mocks/lightning/navigation.js
@@ -48,7 +48,7 @@ export const getNavigateCalledWith = () => {
 
     // If the mock was called (with one object), get the last call and return it.
     // Because the mock is called with a single object, it's at the zero index.
-    return mockNavigate.mock.calls[mockNavigate.mock.calls.length - 1][0];
+    return mockNavigate.mock.lastCall[0];
 };
 
 export const getGenerateUrlCalledWith = () => {
@@ -63,5 +63,5 @@ export const getGenerateUrlCalledWith = () => {
 
     // If the mock was called (with one object), get the last call and return it.
     // Because the mock is called with a single object, it's at the zero index.
-    return mockGenerate.mock.calls[mockGenerate.mock.calls.length - 1][0];
+    return mockGenerate.mock.lastCall[0];
 };

--- a/force-app/test/jest-mocks/lightning/navigation.js
+++ b/force-app/test/jest-mocks/lightning/navigation.js
@@ -46,7 +46,7 @@ export const getNavigateCalledWith = () => {
         };
     }
 
-    // If the mock was called (with one object), get the last call and return it.
+    // The mock was called, so return the most recent last call.
     // Because the mock is called with a single object, it's at the zero index.
     return mockNavigate.mock.lastCall[0];
 };
@@ -61,7 +61,7 @@ export const getGenerateUrlCalledWith = () => {
         };
     }
 
-    // If the mock was called (with one object), get the last call and return it.
+    // The mock was called, so return the most recent last call.
     // Because the mock is called with a single object, it's at the zero index.
     return mockGenerate.mock.lastCall[0];
 };

--- a/force-app/test/jest-mocks/lightning/navigation.js
+++ b/force-app/test/jest-mocks/lightning/navigation.js
@@ -11,19 +11,19 @@ const Navigate = Symbol('Navigate');
 const GenerateUrl = Symbol('GenerateUrl');
 
 // We need the mock to reset between tests, so we hold the state in jest.fn() objects.
-// We use Jest's reflection methods to implement the two CalledWith helpers below so we need to update all the existing tests.
+// We use Jest's reflection methods to implement the two CalledWith helpers below so we don't need to update all the existing tests.
 // A cleaner implementation would just export these two mocks directly for consumption by the test authors to verify the state.
 export const mockNavigate = jest.fn();
 export const mockGenerate = jest.fn();
 
-export const NavigationMixin = Base => {
+export const NavigationMixin = (Base) => {
     return class extends Base {
         [Navigate](pageReference, replace) {
             mockNavigate({ pageReference, replace });
         }
         [GenerateUrl](pageReference) {
             mockGenerate({ pageReference });
-            return new Promise(resolve => resolve('https://www.example.com'));
+            return new Promise((resolve) => resolve('https://www.example.com'));
         }
     };
 };

--- a/force-app/test/jest-mocks/lightning/navigation.js
+++ b/force-app/test/jest-mocks/lightning/navigation.js
@@ -7,19 +7,23 @@
 import { createTestWireAdapter } from '@salesforce/wire-service-jest-util';
 export const CurrentPageReference = createTestWireAdapter(jest.fn());
 
-let _navigatePageReference, _generatePageReference, _replace;
-
 const Navigate = Symbol('Navigate');
 const GenerateUrl = Symbol('GenerateUrl');
-export const NavigationMixin = (Base) => {
+
+// We need the mock to reset between tests, so we hold the state in jest.fn() objects.
+// We use Jest's reflection methods to implement the two CalledWith helpers below so we need to update all the existing tests.
+// A cleaner implementation would just export these two mocks directly for consumption by the test authors to verify the state.
+export const mockNavigate = jest.fn();
+export const mockGenerate = jest.fn();
+
+export const NavigationMixin = Base => {
     return class extends Base {
         [Navigate](pageReference, replace) {
-            _navigatePageReference = pageReference;
-            _replace = replace;
+            mockNavigate({ pageReference, replace });
         }
         [GenerateUrl](pageReference) {
-            _generatePageReference = pageReference;
-            return new Promise((resolve) => resolve('https://www.example.com'));
+            mockGenerate({ pageReference });
+            return new Promise(resolve => resolve('https://www.example.com'));
         }
     };
 };
@@ -32,12 +36,32 @@ NavigationMixin.GenerateUrl = GenerateUrl;
  * invoked with and provide access with this function.
  */
 export const getNavigateCalledWith = () => {
-    return {
-        pageReference: _navigatePageReference,
-        replace: _replace
-    };
+    // If the mock was never called, return the object with undefined properties.
+    // This prevents exceptions when tests destructure this object, allowing them to
+    // fail in more expected ways as the test verifies properties on the pageReference object.
+    if (mockNavigate.mock.calls.length === 0) {
+        return {
+            pageReference: undefined,
+            replace: undefined
+        };
+    }
+
+    // If the mock was called (with one object), get the last call and return it.
+    // Because the mock is called with a single object, it's at the zero index.
+    return mockNavigate.mock.calls[mockNavigate.mock.calls.length - 1][0];
 };
 
-export const getGenerateUrlCalledWith = () => ({
-    pageReference: _generatePageReference
-});
+export const getGenerateUrlCalledWith = () => {
+    // If the mock was never called, return the object with undefined properties.
+    // This prevents exceptions when tests destructure this object, allowing them to
+    // fail in more expected ways as the test verifies properties on the pageReference object.
+    if (mockGenerate.mock.calls.length === 0) {
+        return {
+            pageReference: undefined
+        };
+    }
+
+    // If the mock was called (with one object), get the last call and return it.
+    // Because the mock is called with a single object, it's at the zero index.
+    return mockGenerate.mock.calls[mockGenerate.mock.calls.length - 1][0];
+};


### PR DESCRIPTION
### What does this PR do?

- Uses `jest.fn()` functions to receive the `lightning/navigation` mock calls so the mock can be reset.
- Updates any existing test that used the navigation helper to reset all mocks.

Note: This repository did not contain any existing failures. Please see the first commit (da77ad518aeda26a7be6856c8a13fa3a695b15ea) for a demonstration of how a user might encounter this issue. I'm proposing this fix to minimize overall test changes so that users could easily consume this mock change without a refactor of their existing tests.

A more thorough fix would be to export the `mockNavigate` and `mockGenerate` constants (with better names) and remove the `getNavigateCalledWith` and `getGenerateUrlCalledWith` helper functions but this would be a more extensive refactor and a breaking change for anyone already following the pattern shown in this repository. 

### What issues does this PR fix or reference?

#720 


## The PR fulfills these requirements:

[x] Tests for the proposed changes have been added/updated.
[x] Code linting and formatting was performed.

### Functionality Before

Tests using this mock may incorrectly read state from previous tests, even if `jest.clearAllMocks()` was called.

### Functionality After

This mock is can now be reset.



