### PR TITLE
Added custom library to load scripts in LWR Sites

### DIFF
--- a/force-app/main/default/lwc/libsChartjs/libsChartjs.js
+++ b/force-app/main/default/lwc/libsChartjs/libsChartjs.js
@@ -1,6 +1,16 @@
 import { LightningElement } from 'lwc';
-import { loadScript } from 'lightning/platformResourceLoader';
 import chartjs from '@salesforce/resourceUrl/chartJs';
+import { loadScript } from 'lightning/platformResourceLoader';
+/**
+ * When using this component in an LWR site, please import the below custom implementation of 'loadScript' module
+ * instead of the one from 'lightning/platformResourceLoader'
+ *
+ * import { loadScript } from 'c/resourceLoader';
+ *
+ * This workaround is implemented to get around a limitation of the Lightning Locker library in LWR sites.
+ * Read more about it in the "Lightning Locker Limitations" section of the documentation
+ * https://developer.salesforce.com/docs/atlas.en-us.exp_cloud_lwr.meta/exp_cloud_lwr/template_limitations.htm
+ */
 
 const generateRandomNumber = () => {
     return Math.round(Math.random() * 100);

--- a/force-app/main/default/lwc/libsD3/libsD3.js
+++ b/force-app/main/default/lwc/libsD3/libsD3.js
@@ -2,6 +2,17 @@
 import { LightningElement } from 'lwc';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import { loadScript, loadStyle } from 'lightning/platformResourceLoader';
+/**
+ * When using this component in an LWR site, please import the below custom implementation of 'loadScript' module
+ * instead of the one from 'lightning/platformResourceLoader'
+ *
+ * import { loadScript } from 'c/resourceLoader';
+ *
+ * This workaround is implemented to get around a limitation of the Lightning Locker library in LWR sites.
+ * Read more about it in the "Lightning Locker Limitations" section of the documentation
+ * https://developer.salesforce.com/docs/atlas.en-us.exp_cloud_lwr.meta/exp_cloud_lwr/template_limitations.htm
+ */
+
 import D3 from '@salesforce/resourceUrl/d3';
 import DATA from './data';
 

--- a/force-app/main/default/lwc/libsD3/libsD3.js-meta.xml
+++ b/force-app/main/default/lwc/libsD3/libsD3.js-meta.xml
@@ -6,5 +6,7 @@
         <target>lightning__AppPage</target>
         <target>lightning__RecordPage</target>
         <target>lightning__HomePage</target>
+        <target>lightningCommunity__Page</target>
+        <target>lightningCommunity__Default</target>
     </targets>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/libsFullCalendar/libsFullCalendar.js
+++ b/force-app/main/default/lwc/libsFullCalendar/libsFullCalendar.js
@@ -1,6 +1,16 @@
 import { LightningElement } from 'lwc';
-import { loadScript, loadStyle } from 'lightning/platformResourceLoader';
 import FULL_CALENDAR from '@salesforce/resourceUrl/fullCalendar';
+import { loadScript, loadStyle } from 'lightning/platformResourceLoader';
+/**
+ * When using this component in an LWR site, please import the below custom implementation of 'loadScript' module
+ * instead of the one from 'lightning/platformResourceLoader'
+ *
+ * import { loadScript } from 'c/resourceLoader';
+ *
+ * This workaround is implemented to get around a limitation of the Lightning Locker library in LWR sites.
+ * Read more about it in the "Lightning Locker Limitations" section of the documentation
+ * https://developer.salesforce.com/docs/atlas.en-us.exp_cloud_lwr.meta/exp_cloud_lwr/template_limitations.htm
+ */
 
 export default class LibsFullCalendar extends LightningElement {
     isCalInitialized = false;

--- a/force-app/main/default/lwc/libsFullCalendar/libsFullCalendar.js-meta.xml
+++ b/force-app/main/default/lwc/libsFullCalendar/libsFullCalendar.js-meta.xml
@@ -6,5 +6,7 @@
         <target>lightning__AppPage</target>
         <target>lightning__RecordPage</target>
         <target>lightning__HomePage</target>
+        <target>lightningCommunity__Page</target>
+        <target>lightningCommunity__Default</target>
     </targets>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/resourceLoader/resourceLoader.js
+++ b/force-app/main/default/lwc/resourceLoader/resourceLoader.js
@@ -1,0 +1,18 @@
+/**
+ * Utility function to load a JS file via a script tag.
+ *
+ * This workaround is implemented to get around a limitation of the Lightning Locker library in LWR sites.
+ * Read more about it in the "Lightning Locker Limitations" section of the documentation
+ * https://developer.salesforce.com/docs/atlas.en-us.exp_cloud_lwr.meta/exp_cloud_lwr/template_limitations.htm
+ */
+export function loadScript(ctx, url) {
+    return new Promise((resolve, reject) => {
+        const script = document.createElement('script');
+        script.src = url;
+        script.charset = 'utf-8';
+        script.type = 'text/javascript';
+        document.head.appendChild(script);
+        script.addEventListener('load', resolve);
+        script.addEventListener('error', reject);
+    });
+}

--- a/force-app/main/default/lwc/resourceLoader/resourceLoader.js-meta.xml
+++ b/force-app/main/default/lwc/resourceLoader/resourceLoader.js-meta.xml
@@ -3,9 +3,6 @@
     <apiVersion>57.0</apiVersion>
     <isExposed>true</isExposed>
     <targets>
-        <target>lightning__AppPage</target>
-        <target>lightning__RecordPage</target>
-        <target>lightning__HomePage</target>
         <target>lightningCommunity__Page</target>
         <target>lightningCommunity__Default</target>
     </targets>


### PR DESCRIPTION
### What does this PR do?
Adds a custom library to load scripts in LWR Sites. This workaround is implemented to get around a limitation of the Lightning Locker library in LWR sites. Read more about it in the "Lightning Locker Limitations" section of the [documentation](https://developer.salesforce.com/docs/atlas.en-us.exp_cloud_lwr.meta/exp_cloud_lwr/template_limitations.htm)

### What issues does this PR fix or reference?

#744 

## The PR fulfills these requirements:

[x] Tests for the proposed changes have been added/updated.
[x] Code linting and formatting was performed.

### Functionality Before
Components `libsD3`, `libsChartjs` and `libsFullCalendar` don't load in an LWR site

### Functionality After
Components `libsD3`, `libsChartjs` and `libsFullCalendar` successfully load in an LWR site