### PR TITLE
fix: graphql custom field bug workaround

### DIFF
--- a/force-app/main/default/lwc/contactTile/contactTile.html
+++ b/force-app/main/default/lwc/contactTile/contactTile.html
@@ -2,7 +2,18 @@
     <template lwc:if={contact}>
         <lightning-layout vertical-align="center">
             <lightning-layout-item>
-                <img src={contact.Picture__c} alt="Profile photo" />
+                <img
+                    lwc:if={contact.Picture__c}
+                    src={contact.Picture__c}
+                    alt="Profile photo"
+                />
+                <lightning-icon
+                    lwc:else
+                    icon-name="standard:avatar"
+                    alternative-text="Missing profile photo"
+                    size="medium"
+                    title="Missing profile photo"
+                ></lightning-icon>
             </lightning-layout-item>
             <lightning-layout-item padding="around-small">
                 <p>{contact.Name}</p>

--- a/force-app/main/default/lwc/graphqlContacts/graphqlContacts.js
+++ b/force-app/main/default/lwc/graphqlContacts/graphqlContacts.js
@@ -7,11 +7,7 @@ export default class GraphqlContacts extends LightningElement {
             query getContacts {
                 uiapi {
                     query {
-                        Contact(
-                            where: { Picture__c: { ne: null } }
-                            first: 5
-                            orderBy: { Name: { order: ASC } }
-                        ) {
+                        Contact(first: 5, orderBy: { Name: { order: ASC } }) {
                             edges {
                                 node {
                                     Id
@@ -19,14 +15,6 @@ export default class GraphqlContacts extends LightningElement {
                                         value
                                     }
                                     Phone {
-                                        value
-                                    }
-                                    # We specify an alias for this custom field to ensure
-                                    # that we can find it in the result even if Salesforce's
-                                    # referential integrity logic updates the name. API names
-                                    # for standard fields do not change, so no aliases are
-                                    # needed for those.
-                                    Picture__c: Picture__c {
                                         value
                                     }
                                     Title {
@@ -47,7 +35,7 @@ export default class GraphqlContacts extends LightningElement {
             Id: edge.node.Id,
             Name: edge.node.Name.value,
             Phone: edge.node.Phone.value,
-            Picture__c: edge.node.Picture__c.value,
+            Picture__c: null, // Temporary workaround for a bug that prevents using custom fields in GraphQL
             Title: edge.node.Title.value
         }));
     }

--- a/force-app/main/default/lwc/graphqlContacts/graphqlContacts.js-meta.xml
+++ b/force-app/main/default/lwc/graphqlContacts/graphqlContacts.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <isExposed>true</isExposed>
     <targets>
         <target>lightning__AppPage</target>

--- a/force-app/main/default/lwc/graphqlPagination/graphqlPagination.js-meta.xml
+++ b/force-app/main/default/lwc/graphqlPagination/graphqlPagination.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <isExposed>true</isExposed>
     <targets>
         <target>lightning__AppPage</target>

--- a/force-app/main/default/lwc/graphqlVariables/graphqlVariables.js-meta.xml
+++ b/force-app/main/default/lwc/graphqlVariables/graphqlVariables.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <isExposed>true</isExposed>
     <targets>
         <target>lightning__AppPage</target>


### PR DESCRIPTION
Temporary workaround for a GraphQL bug that prevents the use of custom fields on a standard object.