### PR TITLE
docs: clarify listViewApiName needs updated if not using recipe org

### DIFF
--- a/force-app/main/default/lwc/wireListView/wireListView.js
+++ b/force-app/main/default/lwc/wireListView/wireListView.js
@@ -5,6 +5,7 @@ import CONTACT_OBJECT from '@salesforce/schema/Contact';
 import NAME_FIELD from '@salesforce/schema/Contact.Name';
 
 export default class WireListView extends LightningElement {
+    // Update listViewApiName to be a Contact list view dev name on your org if not using the recipe org
     @wire(getListUi, {
         objectApiName: CONTACT_OBJECT,
         listViewApiName: 'All_Recipes_Contacts',


### PR DESCRIPTION
### What does this PR do?
Document that the listViewApiName should be updated when copying this code to a non-recipe org.

### What issues does this PR fix or reference?
#663 -- seems to be confused that because this is deprecated it is not working. The wire still works despite being deprecated, it is likely they hit an error due to the org not having the list view referenced. 

## The PR fulfills these requirements:
comment only change
[ ] Tests for the proposed changes have been added/updated.
[ ] Code linting and formatting was performed.

### Functionality Before
No code comment which led to confusion when copying code to other orgs.

### Functionality After
Code comment added for clarity.