### PR TITLE
feat: remove "(Beta)" from GraphQL recipes

### DIFF
--- a/force-app/main/default/flexipages/GraphQL.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/GraphQL.flexipage-meta.xml
@@ -46,7 +46,7 @@
         <name>region4</name>
         <type>Region</type>
     </flexiPageRegions>
-    <masterLabel>GraphQL (Beta)</masterLabel>
+    <masterLabel>GraphQL</masterLabel>
     <template>
         <name>flexipage:appHomeTemplateHeaderThreeColumns</name>
     </template>

--- a/force-app/main/default/tabs/GraphQL.tab-meta.xml
+++ b/force-app/main/default/tabs/GraphQL.tab-meta.xml
@@ -2,7 +2,7 @@
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <description>Created by Lightning App Builder</description>
     <flexiPage>GraphQL</flexiPage>
-    <label>GraphQL (Beta)</label>
+    <label>GraphQL</label>
     
     <motif>Custom39: Telescope</motif>
 </CustomTab>


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?

Remove "(Beta)" qualifier from GraphQL recipes tab since GraphQL wire adapter is GA in Winter '24 release.

## The PR fulfills these requirements:

[ n/a ] Tests for the proposed changes have been added/updated.
[ n/a ] Code linting and formatting was performed.

### Functionality Before

GraphQL tab label contained "(Beta)" qualifier.

### Functionality After

"(Beta)" qualifier has been removed from GraphQL tab.