### PR TITLE
enable Local Dev

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -5,7 +5,8 @@
     "features": ["Walkthroughs", "EnableSetPasswordInApi"],
     "settings": {
         "lightningExperienceSettings": {
-            "enableS1DesktopEnabled": true
+            "enableS1DesktopEnabled": true,
+            "enableLightningPreviewPref": true
         },
         "mobileSettings": {
             "enableS1EncryptedStoragePref2": false


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?

This PR enables Local Dev feature in scratch orgs. See [Preview Components with Local Dev](https://developer.salesforce.com/docs/platform/lwc/guide/get-started-test-components.html) for more information.

## The PR fulfills these requirements:

* Tests for the proposed changes have been added/updated: Not needed.
* Code linting and formatting was performed: Not needed

### Functionality Before

The user had to activate Local Dev manually in the Salesforce setup.

### Functionality After

The user does not need to manually activate Local Dev in the Salesforce setup.